### PR TITLE
Globus Pre-Processing

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -73,7 +73,7 @@ WORKDIR /opt/smartscope/
 
 RUN uv venv $VIRTUAL_ENV
 RUN . $VIRTUAL_ENV/bin/activate
-RUN uv sync --active --extra globus && uv cache clean && chmod -R 755 /root
+RUN uv sync --active && uv cache clean && chmod -R 755 /root
 
 COPY --link --from=thirdparty nextpyp-client /opt/nextpyp-client
 RUN uv pip install -e /opt/nextpyp-client

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -73,7 +73,7 @@ WORKDIR /opt/smartscope/
 
 RUN uv venv $VIRTUAL_ENV
 RUN . $VIRTUAL_ENV/bin/activate
-RUN uv sync --active && uv cache clean && chmod -R 755 /root
+RUN uv sync --active --extra globus && uv cache clean && chmod -R 755 /root
 
 COPY --link --from=thirdparty nextpyp-client /opt/nextpyp-client
 RUN uv pip install -e /opt/nextpyp-client

--- a/Smartscope/core/pipelines/__init__.py
+++ b/Smartscope/core/pipelines/__init__.py
@@ -9,3 +9,4 @@ from .cryosparc_live import CryoSPARCPipeline
 from .nextpyp_preprocessing_pipeline import NextPYPPreprocessingPipeline
 from .nextpyp_preprocessing_pipeline_form import NextPYPPreprocessingPipelineForm
 from .nextpyp_preprocessing_cmd_kwargs import NextPYPPreprocessingCmdKwargs
+from .globus_preprocessing_pipeline import GlobusPreprocessingPipeline

--- a/Smartscope/core/pipelines/globus_flow_definition.json
+++ b/Smartscope/core/pipelines/globus_flow_definition.json
@@ -1,0 +1,45 @@
+{
+  "Comment": "SmartScope Globus Preprocessing Flow: transfer files to HPC, run a command via Globus Compute, transfer results back. Users can register their own flows with different compute functions.",
+  "StartAt": "TransferToHPC",
+  "States": {
+    "TransferToHPC": {
+      "Type": "Action",
+      "ActionUrl": "https://transfer.actions.globus.org/transfer",
+      "ActionScope": "urn:globus:auth:scope:transfer.api.globus.org:all",
+      "Parameters": {
+        "source_endpoint.$": "$.input.source_collection",
+        "destination_endpoint.$": "$.input.destination_collection",
+        "DATA.$": "$.input.transfer_items",
+        "label.$": "$.input.label"
+      },
+      "ResultPath": "$.TransferToHPC",
+      "Next": "RunCommand"
+    },
+    "RunCommand": {
+      "Type": "Action",
+      "ActionUrl": "https://compute.actions.globus.org",
+      "ActionScope": "https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all",
+      "WaitTime": 7200,
+      "Parameters": {
+        "endpoint.$": "$.input.compute_endpoint",
+        "function.$": "$.input.compute_function",
+        "kwargs.$": "$.input.compute_kwargs"
+      },
+      "ResultPath": "$.ComputeResult",
+      "Next": "TransferResultsBack"
+    },
+    "TransferResultsBack": {
+      "Type": "Action",
+      "ActionUrl": "https://transfer.actions.globus.org/transfer",
+      "ActionScope": "urn:globus:auth:scope:transfer.api.globus.org:all",
+      "Parameters": {
+        "source_endpoint.$": "$.input.destination_collection",
+        "destination_endpoint.$": "$.input.source_collection",
+        "DATA.$": "$.ComputeResult.details.results[0].output.transfer_items",
+        "label.$": "$.input.results_label"
+      },
+      "ResultPath": "$.TransferResultsBack",
+      "End": true
+    }
+  }
+}

--- a/Smartscope/core/pipelines/globus_pipeline_config.py
+++ b/Smartscope/core/pipelines/globus_pipeline_config.py
@@ -1,0 +1,64 @@
+
+from typing import Any, Dict
+from pydantic import BaseModel
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class GlobusPipelineConfig(BaseModel):
+
+    # How to group images into flow runs
+    #   per_micrograph: one flow per high-mag image (immediate)
+    #   per_group: one flow per BIS group
+    #   per_square: one flow per grid square (wait until square is done)
+    grouping: str = "per_group"
+
+    # Globus Compute endpoint where jobs run
+    globus_compute_endpoint_id: str = ""
+
+    # Globus Compute function to invoke (registered processing function)
+    globus_compute_function_id: str = ""
+
+    # Globus Flow ID (deployed flow that chains transfer -> compute -> transfer)
+    globus_flow_id: str = ""
+
+    # Globus Transfer collection IDs
+    source_collection_id: str = ""
+    destination_collection_id: str = ""
+
+    # Path mapping
+    source_base_path: str = ""
+    destination_base_path: str = ""  # Globus collection path, e.g. "/CryoEM/Projects"
+    destination_filesystem_root: str = ""  # HPC filesystem mount, e.g. "/mnt/blackmore/ext-superluminal"
+
+    # ===== Slot-to-project mapping (autoloader positions 1-12) =====
+    slot_1: str = ""
+    slot_2: str = ""
+    slot_3: str = ""
+    slot_4: str = ""
+    slot_5: str = ""
+    slot_6: str = ""
+    slot_7: str = ""
+    slot_8: str = ""
+    slot_9: str = ""
+    slot_10: str = ""
+    slot_11: str = ""
+    slot_12: str = ""
+
+    # ===== Concurrency =====
+    max_concurrent_flows: int = 1
+    group_settle_seconds: int = 60  # Wait N seconds after newest image before submitting a group
+
+    # ===== Extra config passed through to the compute function =====
+    # Key-value pairs merged into the manifest "config" dict.
+    # The compute function defines what it expects; SmartScope passes these through.
+    extra_config: Dict[str, Any] = {}
+
+    # ===== Globus Auth =====
+    globus_client_id: str = "7df9d534-fb19-4d79-8e83-642f1cdcf081"
+    token_file: str = "/opt/config/smartscope_tokens.json"
+
+    def get_project_for_slot(self, position: int) -> str:
+        """Return the HPC project path for a given autoloader slot (1-12)."""
+        return getattr(self, f"slot_{position}", "")

--- a/Smartscope/core/pipelines/globus_pipeline_form.py
+++ b/Smartscope/core/pipelines/globus_pipeline_form.py
@@ -1,0 +1,250 @@
+
+from django import forms
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+# Default token file and client ID
+DEFAULT_TOKEN_FILE = '/opt/config/smartscope_tokens.json'
+DEFAULT_CLIENT_ID = '7df9d534-fb19-4d79-8e83-642f1cdcf081'
+
+
+def _get_globus_choices():
+    """Query Globus APIs for available collections, flows, and compute endpoints.
+
+    Returns a dict of field_name -> [(value, label), ...] choices.
+    Falls back to empty lists if tokens are missing or API fails.
+    """
+    choices = {
+        'source_collection_id': [],
+        'destination_collection_id': [],
+        'globus_flow_id': [],
+        'globus_compute_endpoint_id': [],
+    }
+
+    try:
+        from globus_sdk import (
+            NativeAppAuthClient, TransferClient, FlowsClient,
+            RefreshTokenAuthorizer,
+        )
+
+        token_path = Path(DEFAULT_TOKEN_FILE)
+        if not token_path.exists():
+            return choices
+
+        tokens = json.loads(token_path.read_text())
+        auth_client = NativeAppAuthClient(DEFAULT_CLIENT_ID)
+
+        # Transfer collections
+        if 'transfer.api.globus.org' in tokens:
+            t = tokens['transfer.api.globus.org']
+            authorizer = RefreshTokenAuthorizer(
+                t['refresh_token'], auth_client,
+                access_token=t['access_token'],
+                expires_at=t['expires_at_seconds'],
+            )
+            tc = TransferClient(authorizer=authorizer)
+
+            collection_choices = []
+            for ep in tc.endpoint_search(filter_scope='my-endpoints'):
+                label = f"{ep['display_name']}  ({ep['id'][:8]}…)"
+                collection_choices.append((ep['id'], label))
+            # Also search recently used
+            for ep in tc.endpoint_search(filter_scope='recently-used'):
+                entry = (ep['id'], f"{ep['display_name']}  ({ep['id'][:8]}…)")
+                if entry not in collection_choices:
+                    collection_choices.append(entry)
+
+            choices['source_collection_id'] = collection_choices
+            choices['destination_collection_id'] = collection_choices
+
+        # Flows
+        if 'flows.globus.org' in tokens:
+            t = tokens['flows.globus.org']
+            authorizer = RefreshTokenAuthorizer(
+                t['refresh_token'], auth_client,
+                access_token=t['access_token'],
+                expires_at=t['expires_at_seconds'],
+            )
+            fc = FlowsClient(authorizer=authorizer)
+
+            flow_choices = []
+            for flow in fc.list_flows():
+                label = f"{flow['title']}  ({flow['id'][:8]}…)"
+                flow_choices.append((flow['id'], label))
+            choices['globus_flow_id'] = flow_choices
+
+        # Compute endpoints
+        if 'funcx_service' in tokens:
+            try:
+                from globus_sdk import ComputeClientV2
+                t = tokens['funcx_service']
+                authorizer = RefreshTokenAuthorizer(
+                    t['refresh_token'], auth_client,
+                    access_token=t['access_token'],
+                    expires_at=t['expires_at_seconds'],
+                )
+                cc = ComputeClientV2(authorizer=authorizer)
+                endpoint_choices = []
+                for ep in cc.get_endpoints().data:
+                    name = ep.get('display_name', ep.get('name', ep['uuid'][:8]))
+                    label = f"{name}  ({ep['uuid'][:8]}…)"
+                    endpoint_choices.append((ep['uuid'], label))
+                choices['globus_compute_endpoint_id'] = endpoint_choices
+            except Exception as e:
+                logger.debug(f'Could not list compute endpoints: {e}')
+
+    except Exception as e:
+        logger.warning(f'Could not fetch Globus choices: {e}')
+
+    return choices
+
+
+class GlobusPipelineForm(forms.Form):
+
+    grouping = forms.ChoiceField(
+        choices=[
+            ('per_micrograph', 'Per Micrograph — one flow per image (immediate)'),
+            ('per_group', 'Per Group — one flow per BIS group'),
+            ('per_square', 'Per Square — one flow per grid square'),
+        ],
+        widget=forms.RadioSelect(attrs={'class': ''}),
+        initial='per_group',
+        help_text='How to batch images into Globus Flow runs.',
+    )
+
+    max_concurrent_flows = forms.IntegerField(
+        label='Max concurrent flows',
+        initial=1,
+        min_value=1,
+        max_value=20,
+        help_text='Maximum number of Globus Flow runs to have active simultaneously.',
+    )
+
+    # ===== Globus — these become dropdowns populated from the API =====
+
+    globus_compute_endpoint_id = forms.ChoiceField(
+        label='Globus Compute Endpoint',
+        choices=[],
+        help_text='HPC endpoint where compute functions run. Leave blank for transfer-only mode.',
+    )
+
+    globus_compute_function_id = forms.CharField(
+        label='Compute Function ID',
+        widget=forms.TextInput(attrs={'placeholder': 'UUID from setup_globus.py register-func'}),
+        help_text='Function UUID from registration. Leave blank for transfer-only mode.',
+    )
+
+    globus_flow_id = forms.ChoiceField(
+        label='Globus Flow',
+        choices=[],
+        help_text='Select a deployed Globus Flow. Leave blank for transfer-only mode (files transferred, no processing).',
+    )
+
+    source_collection_id = forms.ChoiceField(
+        label='Source Collection',
+        choices=[],
+        help_text='Globus collection on the microscope side.',
+    )
+
+    destination_collection_id = forms.ChoiceField(
+        label='Destination Collection',
+        choices=[],
+        help_text='Globus collection on the HPC side.',
+    )
+
+    source_base_path = forms.CharField(
+        label='Source Base Path',
+        help_text='Globus path prefix mapping to the container data root. '
+                  'e.g. "/SmartScope" if that maps to /mnt/data inside the container.',
+    )
+
+    destination_base_path = forms.CharField(
+        label='Destination Base Path (Globus)',
+        help_text='Globus collection path for HPC projects, e.g. "/CryoEM/Projects".',
+    )
+
+    destination_filesystem_root = forms.CharField(
+        label='Destination Filesystem Root (HPC)',
+        help_text='HPC filesystem mount point for the Globus collection root, e.g. "/mnt/blackmore/ext-superluminal".',
+    )
+
+    # ===== Slot-to-Project Mapping =====
+
+    slot_1 = forms.CharField(
+        label='Slot 1',
+        help_text='HPC project path. e.g. "Lodos/Apoferritin". Same value = same project. Empty = skip.',
+    )
+    slot_2 = forms.CharField(label='Slot 2')
+    slot_3 = forms.CharField(label='Slot 3')
+    slot_4 = forms.CharField(label='Slot 4')
+    slot_5 = forms.CharField(label='Slot 5')
+    slot_6 = forms.CharField(label='Slot 6')
+    slot_7 = forms.CharField(label='Slot 7')
+    slot_8 = forms.CharField(label='Slot 8')
+    slot_9 = forms.CharField(label='Slot 9')
+    slot_10 = forms.CharField(label='Slot 10')
+    slot_11 = forms.CharField(label='Slot 11')
+    slot_12 = forms.CharField(label='Slot 12')
+
+    # ===== Extra Config (passed through to compute function) =====
+
+    extra_config = forms.CharField(
+        label='Compute Function Parameters',
+        widget=forms.Textarea(attrs={'rows': 10, 'placeholder':
+            '{\n'
+            '  "do_motioncor": true,\n'
+            '  "do_ctf": true,\n'
+            '  "do_picking": true,\n'
+            '  "dose_per_frame": 1.0,\n'
+            '  "picking_threshold": 0.3\n'
+            '}'}),
+        help_text='JSON key-value pairs passed to the compute function. '
+                  'Parameters depend on the selected function.',
+    )
+
+    # ===== Auth =====
+
+    globus_client_id = forms.CharField(
+        label='Globus Client ID',
+        initial='7df9d534-fb19-4d79-8e83-642f1cdcf081',
+        help_text='Globus app client ID (pre-filled with SmartScope app).',
+    )
+
+    token_file = forms.CharField(
+        label='Token File',
+        initial='/opt/config/smartscope_tokens.json',
+        help_text='Path to cached Globus auth tokens.',
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Populate dynamic dropdown choices from Globus APIs
+        globus_choices = _get_globus_choices()
+        for field_name, field_choices in globus_choices.items():
+            if field_name in self.fields and field_choices:
+                self.fields[field_name].choices = [('', '— Select —')] + field_choices
+
+        for visible in self.visible_fields():
+            widget = visible.field.widget
+            if isinstance(widget, forms.CheckboxInput):
+                widget.attrs['class'] = 'form-check-input'
+            elif not isinstance(widget, forms.RadioSelect):
+                widget.attrs['class'] = 'form-control'
+            visible.field.required = False
+
+    def clean_extra_config(self):
+        value = self.cleaned_data.get('extra_config', '').strip()
+        if not value:
+            return {}
+        try:
+            parsed = json.loads(value)
+            if not isinstance(parsed, dict):
+                raise forms.ValidationError('Must be a JSON object (key-value pairs).')
+            return parsed
+        except json.JSONDecodeError as e:
+            raise forms.ValidationError(f'Invalid JSON: {e}')

--- a/Smartscope/core/pipelines/globus_preprocessing_pipeline.py
+++ b/Smartscope/core/pipelines/globus_preprocessing_pipeline.py
@@ -1,0 +1,829 @@
+
+import json
+import logging
+import threading
+import time
+from pathlib import Path
+from typing import Dict, List, Set
+
+from django.db import transaction
+
+from Smartscope.core.db_manipulations import websocket_update
+from Smartscope.core.frames import get_smartscope_frames_dir
+from Smartscope.core.models.grid import AutoloaderGrid
+from Smartscope.core.models.high_mag import HighMagModel
+from Smartscope.core.models.hole import HoleModel
+from Smartscope.core.models.models_actions import update_fields
+from Smartscope.core.models import Selector
+
+from .preprocessing_pipeline import PreprocessingPipeline
+from .globus_pipeline_config import GlobusPipelineConfig
+from .globus_pipeline_form import GlobusPipelineForm
+
+logger = logging.getLogger(__name__)
+
+# Mapping from result JSON keys to Selector plugin names.
+# Each entry creates a Selector row per highmag with value from the result.
+# Plugin YAMLs in config/smartscope/plugins/ define display (colors, limits, exclude).
+RESULT_SELECTORS = {
+    'particle_count': 'Particle count',
+    'mean_pick_score': 'Pick score',
+    'ctf_max_resolution': 'CTF resolution',
+    'total_motion': 'Total motion',
+    'ice_thickness': 'Ice thickness',
+}
+
+TRANSFER_SCOPE = "urn:globus:auth:scope:transfer.api.globus.org:all"
+FLOWS_SCOPE = "https://auth.globus.org/scopes/eec9b274-0c81-4334-bdc2-54e90e689b9e/flow_user"
+
+
+
+# ---- Globus Auth Helpers ----
+
+def _load_tokens(token_file: str) -> dict:
+    path = Path(token_file).expanduser()
+    if not path.exists():
+        raise FileNotFoundError(
+            f"No cached Globus tokens at {path}. "
+            f"Run: python globus_login.py get-url && python globus_login.py exchange <code>"
+        )
+    return json.loads(path.read_text())
+
+
+def _save_tokens(token_file: str, tokens: dict):
+    path = Path(token_file).expanduser()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(tokens, indent=2))
+    path.chmod(0o600)
+
+
+def _build_transfer_client(cmd_data: GlobusPipelineConfig):
+    from globus_sdk import NativeAppAuthClient, TransferClient, RefreshTokenAuthorizer
+
+    tokens = _load_tokens(cmd_data.token_file)
+    transfer_tokens = tokens["transfer.api.globus.org"]
+
+    auth_client = NativeAppAuthClient(cmd_data.globus_client_id)
+    authorizer = RefreshTokenAuthorizer(
+        transfer_tokens["refresh_token"],
+        auth_client,
+        access_token=transfer_tokens["access_token"],
+        expires_at=transfer_tokens["expires_at_seconds"],
+        on_refresh=lambda td: _save_tokens(cmd_data.token_file, {
+            **_load_tokens(cmd_data.token_file),
+            "transfer.api.globus.org": td.by_resource_server["transfer.api.globus.org"],
+        }),
+    )
+    return TransferClient(authorizer=authorizer)
+
+
+def _build_flows_client(cmd_data: GlobusPipelineConfig):
+    """Build a Globus Flows client (SpecificFlowClient) for running flows."""
+    from globus_sdk import NativeAppAuthClient, SpecificFlowClient, RefreshTokenAuthorizer
+
+    tokens = _load_tokens(cmd_data.token_file)
+    # The flow-specific scope tokens are keyed by the flow's UUID.
+    # Fall back to flows.globus.org if flow-specific tokens aren't available.
+    flow_tokens = tokens.get(
+        cmd_data.globus_flow_id,
+        tokens.get("flows.globus.org", tokens.get("transfer.api.globus.org"))
+    )
+
+    auth_client = NativeAppAuthClient(cmd_data.globus_client_id)
+    authorizer = RefreshTokenAuthorizer(
+        flow_tokens["refresh_token"],
+        auth_client,
+        access_token=flow_tokens["access_token"],
+        expires_at=flow_tokens["expires_at_seconds"],
+    )
+    return SpecificFlowClient(cmd_data.globus_flow_id, authorizer=authorizer)
+
+
+# ---- Path Mapping ----
+
+def _container_to_globus_path(container_path: str, source_base_path: str,
+                              container_root: str = "") -> str:
+    """Convert a container path to a Globus collection path.
+
+    Args:
+        container_path: Full path inside the container
+        source_base_path: Globus collection prefix (e.g. "/SmartScope")
+        container_root: Container-side prefix to strip (e.g. "/mnt/arctica/Superluminal/SmartScope")
+                        Derived from detector.frames_directory at runtime.
+    """
+    rel = container_path
+    if container_root and rel.startswith(container_root):
+        rel = rel[len(container_root):]
+    return f"{source_base_path.rstrip('/')}/{rel.lstrip('/')}"
+
+
+def _globus_dest_path(container_path: str, destination_base_path: str,
+                      project_path: str, square: str, group: str) -> str:
+    """Build destination path on HPC.
+
+    e.g. /CryoEM/Projects/Rori_SUN-0018080/Movies/Square-14/Group-42/frame.tif
+    """
+    filename = Path(container_path).name
+    return (f"{destination_base_path.rstrip('/')}/"
+            f"{project_path.strip('/')}/"
+            f"Movies/{square}/{group}/{filename}")
+
+
+class GlobusPreprocessingPipeline(PreprocessingPipeline):
+
+    verbose_name = 'Globus Preprocessing Pipeline'
+    name = 'globusPipeline'
+    description = 'Globus Transfer & Globus Compute via Globus Flows. Users can write and register their own flows to perform any combination of transfer, compute, and return.'
+
+    cmdkwargs_handler = GlobusPipelineConfig
+    pipeline_form = GlobusPipelineForm
+
+    incomplete_processes: List = []
+    to_update: List = []
+
+    def __init__(self, grid: AutoloaderGrid, cmd_data: Dict):
+        super().__init__(grid=grid)
+        self.microscope = self.grid.session_id.microscope_id
+        self.detector = self.grid.session_id.detector_id
+        self.cmd_data = self.cmdkwargs_handler.parse_obj(cmd_data)
+
+        # Resolve this grid's remote project from slot mapping
+        self.grid_position = getattr(self.grid, 'position', None)
+        self.project_path = ""
+        if self.grid_position:
+            self.project_path = self.cmd_data.get_project_for_slot(self.grid_position)
+
+        # Frames directory for this grid (where SerialEM writes .tif/.mrc files)
+        self.frames_dir = get_smartscope_frames_dir(self.grid)
+
+        # Container-side roots to strip when building Globus paths.
+        # Frames and data may be mounted differently but map to the same Globus collection.
+        # frames: /mnt/arctica/Superluminal/SmartScope/... -> /SmartScope/...
+        # data:   /mnt/data/...                            -> /SmartScope/...
+        self.container_frames_root = str(self.detector.frames_directory).rstrip('/')
+        self.container_data_root = str(self.grid.directory).rsplit(
+            str(self.grid.session_id.working_directory), 1)[0].rstrip('/')
+
+        self._stop = threading.Event()
+        self._submitted_groups: Set[str] = set()  # track submitted grouping keys
+        self._active_flow_runs: Dict[str, dict] = {}  # flow_run_id -> {batch, group_key}
+
+        self.tc = None       # TransferClient (for transfer_only mode)
+        self.fc = None       # SpecificFlowClient (for transfer_and_process mode)
+        self.fc_general = None  # FlowsClient (for checking run status)
+
+    # ---- Init ----
+
+    def _init_globus_clients(self):
+        self.tc = _build_transfer_client(self.cmd_data)
+        logger.info("Globus Transfer client initialized")
+
+        if not self.cmd_data.globus_flow_id:
+            logger.info("No flow ID configured — running in transfer-only mode "
+                        "(files transferred to HPC, no remote processing)")
+        else:
+            try:
+                self.fc = _build_flows_client(self.cmd_data)
+                # Also build a general FlowsClient for checking run status
+                from globus_sdk import FlowsClient
+                tokens = _load_tokens(self.cmd_data.token_file)
+                flows_tokens = tokens.get('flows.globus.org', {})
+                if flows_tokens:
+                    from globus_sdk import NativeAppAuthClient, RefreshTokenAuthorizer
+                    auth_client = NativeAppAuthClient(self.cmd_data.globus_client_id)
+                    authorizer = RefreshTokenAuthorizer(
+                        flows_tokens['refresh_token'], auth_client,
+                        access_token=flows_tokens['access_token'],
+                        expires_at=flows_tokens['expires_at_seconds'],
+                    )
+                    self.fc_general = FlowsClient(authorizer=authorizer)
+                logger.info("Globus Flows client initialized")
+            except Exception as e:
+                logger.warning(f"Could not init Flows client: {e}. Falling back to transfer-only mode.")
+
+    # ---- Grouping Logic ----
+
+    def _group_key(self, hm: HighMagModel) -> str:
+        """Return a grouping key for a HighMagModel based on the configured grouping."""
+        if self.cmd_data.grouping == 'per_micrograph':
+            return str(hm.pk)
+        elif self.cmd_data.grouping == 'per_group':
+            # BIS group: all holes sharing the same group identifier
+            hole = getattr(hm, 'hole_id', None)
+            if hole and getattr(hole, 'bis_group', None):
+                return str(hole.bis_group)
+            return str(hm.pk)
+        elif self.cmd_data.grouping == 'per_square':
+            # All holes in the same square
+            return str(hm.hole_id.square_id.pk) if hm.hole_id else str(hm.pk)
+        return str(hm.pk)
+
+    def _group_is_complete(self, group_key: str, group_items: List) -> bool:
+        """Check if all items in a group have been acquired (ready to submit).
+
+        For grouped modes, we require a settle period: the newest image in the
+        group must be older than ``group_settle_seconds`` so that we don't
+        submit a partial BIS group while the microscope is still acquiring.
+        """
+        if self.cmd_data.grouping == 'per_micrograph':
+            return True  # always ready
+        if not all(hm.status == 'acquired' for hm in group_items):
+            return False
+        # Require that the group has been stable (no new images) for N seconds
+        from django.utils import timezone
+        settle = getattr(self.cmd_data, 'group_settle_seconds', 60)
+        newest = max(hm.completion_time for hm in group_items)
+        age = (timezone.now() - newest).total_seconds()
+        if age < settle:
+            return False
+        return True
+
+    def _build_groups(self) -> Dict[str, List]:
+        """Group incomplete processes by grouping key."""
+        groups = {}
+        for hm in self.incomplete_processes:
+            key = self._group_key(hm)
+            groups.setdefault(key, []).append(hm)
+        return groups
+
+    # ---- Main loop ----
+
+    def start(self):
+        if not self.project_path:
+            logger.info(f'Grid {self.grid.grid_id} (slot {self.grid_position}): '
+                        f'no remote project assigned, skipping.')
+            return
+
+        logger.info(f'Starting Globus pipeline: grouping={self.cmd_data.grouping}, '
+                     f'project={self.project_path}, grid={self.grid.grid_id}')
+        self._init_globus_clients()
+
+        logger.info(f'Entering main loop. Stop={self._stop.is_set()}, stop_file={self.is_stop_file()}')
+
+        while not self._stop.is_set() and not self.is_stop_file():
+            self.list_incomplete_processes()
+            logger.debug(f'Incomplete: {len(self.incomplete_processes)} images')
+
+            # Group and submit ready batches (limit concurrent flow runs)
+            MAX_CONCURRENT_FLOWS = self.cmd_data.max_concurrent_flows
+            groups = self._build_groups()
+            for group_key, batch in groups.items():
+                if len(self._active_flow_runs) >= MAX_CONCURRENT_FLOWS:
+                    logger.debug(f'Max concurrent flows ({MAX_CONCURRENT_FLOWS}) reached, waiting...')
+                    break
+                if group_key in self._submitted_groups:
+                    continue
+                if self._group_is_complete(group_key, batch):
+                    try:
+                        self._submit_group(group_key, batch)
+                    except Exception as e:
+                        logger.error(f'Failed to submit group {group_key}: {e}')
+                        break  # Stop submitting on error, retry next loop
+
+            # Check for completed flow runs
+            self._check_flow_runs()
+
+            # Move any thumbnails from frames mount to data mount
+            self._sync_thumbnails()
+
+            # Done?
+            self.grid.refresh_from_db()
+            if self._is_done():
+                logger.info('All images processed. Exiting.')
+                break
+
+            time.sleep(5)  # brief sleep between loop iterations
+
+    def _is_done(self):
+        return (
+            self.grid.status in ['complete', 'error']
+            and len(self._active_flow_runs) == 0
+            and not self.incomplete_processes
+        )
+
+    # ---- Process listing ----
+
+    def list_incomplete_processes(self):
+        self.incomplete_processes = list(
+            HighMagModel.parent_manager
+            .filter(grid_id=self.grid.pk, status__in=['acquired', 'skipped'])
+            .order_by('status', 'completion_time')
+        )
+
+    # ---- Submission ----
+
+    def _flow_label(self, group_key: str, batch: List) -> str:
+        """Build a human-readable label like SmartScope_GridName_Square-3_Group-42."""
+        grid = self.grid.name
+        square = ''
+        if batch:
+            hole = getattr(batch[0], 'hole_id', None)
+            if hole:
+                sq = getattr(hole, 'square_id', None)
+                if sq:
+                    square = f'Square-{sq.number}'
+        parts = ['SmartScope', grid]
+        if square:
+            parts.append(square)
+        if self.cmd_data.grouping == 'per_micrograph':
+            parts.append(f'Mic-{batch[0].number}' if batch else group_key)
+        else:
+            parts.append(f'Group-{group_key}')
+        return '_'.join(parts)
+
+    def _submit_group(self, group_key: str, batch: List):
+        """Submit a group of images as a Globus Flow run (or transfer-only)."""
+        label = self._flow_label(group_key, batch)
+        logger.info(f'Submitting {label}: {len(batch)} images')
+        self._submitted_groups.add(group_key)
+
+        # Get square and group for destination path
+        square = 'Unknown'
+        if batch:
+            hole = getattr(batch[0], 'hole_id', None)
+            if hole:
+                sq = getattr(hole, 'square_id', None)
+                if sq:
+                    square = f'Square-{sq.number}'
+        group = f'Group-{group_key}'
+
+        # Build file list from actual frame paths (include .mdoc sidecar files)
+        file_pairs = []
+        gain_ref_added = set()
+        for hm in batch:
+            if not hm.frames:
+                logger.warning(f'No frames file for {hm.pk}, skipping')
+                continue
+            container_path = str(self.frames_dir / hm.frames)
+
+            src = _container_to_globus_path(container_path, self.cmd_data.source_base_path,
+                                                self.container_frames_root)
+            dst = _globus_dest_path(container_path, self.cmd_data.destination_base_path,
+                                    self.project_path, square, group)
+            file_pairs.append((src, dst))
+
+            mdoc_path = container_path + '.mdoc'
+            if Path(mdoc_path).exists():
+                mdoc_src = _container_to_globus_path(mdoc_path, self.cmd_data.source_base_path,
+                                                     self.container_frames_root)
+                mdoc_dst = dst + '.mdoc'
+                file_pairs.append((mdoc_src, mdoc_dst))
+
+                # Include the gain reference from the mdoc
+                if not gain_ref_added:
+                    try:
+                        with open(mdoc_path) as f:
+                            for line in f:
+                                if line.strip().startswith('GainReference'):
+                                    gain_name = line.split('=', 1)[1].strip()
+                                    if gain_name:
+                                        frames_dir = str(Path(container_path).parent)
+                                        gain_path = str(Path(frames_dir) / gain_name)
+                                        if Path(gain_path).exists():
+                                            gain_src = _container_to_globus_path(
+                                                gain_path, self.cmd_data.source_base_path,
+                                                self.container_frames_root)
+                                            gain_dst = (f"{self.cmd_data.destination_base_path.rstrip('/')}/"
+                                                        f"{self.project_path.strip('/')}/{gain_name}")
+                                            file_pairs.append((gain_src, gain_dst))
+                                            gain_ref_added.add(gain_name)
+                                            logger.info(f'Including gain reference: {gain_name}')
+                                    break
+                    except Exception:
+                        pass
+
+        # Pass gain reference name so it can be included in the manifest config
+        gain_ref_name = next(iter(gain_ref_added), "")
+
+        if self.fc:
+            self._start_flow_run(group_key, batch, file_pairs, label, gain_ref_name)
+        else:
+            self._start_transfer_only(group_key, batch, file_pairs, label, gain_ref_name)
+
+    def _build_manifest(self, group_key: str, batch: List, file_pairs: List,
+                         flow_run_id: str = "", gain_ref: str = "") -> dict:
+        """Build a HPC-side manifest for this batch.
+
+        The manifest tells the HPC compute function:
+        - What movies were transferred (relative to remote project dir)
+        - The flow_run_id to callback when processing is done
+        - Any metadata overrides (pixel size, voltage, etc.)
+        """
+        batch_id = self._flow_label(group_key, batch)
+
+        # Movie paths relative to remote project dir
+        # (SmartScopeMode resolves them to absolute via project_dir)
+        dest_globus_base = (f"{self.cmd_data.destination_base_path.rstrip('/')}/"
+                            f"{self.project_path.strip('/')}")
+        movies = []
+        for _, dst in file_pairs:
+            # dst is a Globus collection path like /CryoEM/Projects/Rori/Movies/grid/frame.tif
+            # Strip the project prefix to get relative path like Movies/grid/frame.tif
+            rel = dst
+            if rel.startswith(dest_globus_base):
+                rel = rel[len(dest_globus_base):].lstrip('/')
+            movies.append(rel)
+
+        # Build config dict matching the compute function's expected config
+        fs_root = self.cmd_data.destination_filesystem_root.rstrip('/')
+        dest_globus = (f"{self.cmd_data.destination_base_path.rstrip('/')}/"
+                       f"{self.project_path.strip('/')}")
+        project_fs = f"{fs_root}/{dest_globus.lstrip('/')}"
+        output_dir = f"{project_fs}/LivePreprocess/job001"
+
+        config = {
+            "project_dir": project_fs,
+            "output_dir": output_dir,
+        }
+
+        # Microscope-derived values (SmartScope provides these automatically)
+        if hasattr(self.detector, 'pixel_size') and self.detector.pixel_size:
+            config["pixel_size"] = float(self.detector.pixel_size)
+        if hasattr(self.microscope, 'voltage') and self.microscope.voltage:
+            config["voltage"] = int(self.microscope.voltage)
+        if hasattr(self.microscope, 'spherical_abberation') and self.microscope.spherical_abberation:
+            config["cs"] = float(self.microscope.spherical_abberation)
+        if gain_ref:
+            config["gain_reference"] = gain_ref
+        if hasattr(self.detector, 'gain_rot') and self.detector.gain_rot is not None:
+            config["gain_rotation"] = int(self.detector.gain_rot)
+        # gain_flip in DB is IMOD convention; MotionCor3 uses RELION convention (inverted)
+        if hasattr(self.detector, 'gain_flip'):
+            config["gain_flip"] = int(not self.detector.gain_flip)
+
+        # Merge user-provided extra config (processing params for the compute function)
+        config.update(self.cmd_data.extra_config)
+
+        # Map movie filenames to Globus destination paths for thumbnails.
+        # The compute function uses this to put thumbnails directly where SmartScope expects them.
+        grid_globus = _container_to_globus_path(
+            str(self.grid.directory), self.cmd_data.source_base_path,
+            self.container_data_root
+        )
+        thumbnail_map = {}
+        for hm in batch:
+            if hm.frames:
+                movie_name = Path(hm.frames).name
+                thumbnail_map[movie_name] = {
+                    "png": f"{grid_globus}/pngs/{hm.name}.png",
+                    "ctf": f"{grid_globus}/{hm.name}/ctf.png",
+                }
+
+        return {
+            "batch_id": batch_id,
+            "flow_run_id": flow_run_id,
+            "movies": movies,
+            "config": config,
+            "grid_id": self.grid.grid_id,
+            "thumbnail_destinations": thumbnail_map,
+        }
+
+    def _transfer_manifest(self, manifest: dict):
+        """Transfer the manifest JSON to the remote project's Manifests/ dir on HPC."""
+        from globus_sdk import TransferData
+
+        batch_id = manifest["batch_id"]
+        dest_base = (f"{self.cmd_data.destination_base_path.rstrip('/')}/"
+                     f"{self.project_path.strip('/')}")
+
+        # Write manifest to the frames directory (same Globus mount as the frames)
+        manifests_dir = self.frames_dir / "manifests"
+        manifests_dir.mkdir(parents=True, exist_ok=True)
+        local_path = manifests_dir / f"{batch_id}.json"
+        local_path.write_text(json.dumps(manifest, indent=2))
+
+        src_manifest = _container_to_globus_path(
+            str(local_path), self.cmd_data.source_base_path,
+            self.container_frames_root
+        )
+        dst_manifest = (f"{dest_base}/LivePreprocess/job001/"
+                        f"Manifests/{batch_id}.json")
+
+        td = TransferData(
+            source_endpoint=self.cmd_data.source_collection_id,
+            destination_endpoint=self.cmd_data.destination_collection_id,
+            label=f'Manifest {batch_id}',
+        )
+        td.add_item(src_manifest, dst_manifest)
+
+        result = self.tc.submit_transfer(td)
+        logger.info(f'Manifest transfer submitted: {result["task_id"]} '
+                     f'for batch {batch_id}')
+
+    def _start_flow_run(self, group_key: str, batch: List, file_pairs: List, label: str = "", gain_ref: str = ""):
+        """Start a Globus Flow run: transfer frames+manifest -> compute -> transfer back."""
+        # Globus collection path (for transfers)
+        dest_globus_dir = (f"{self.cmd_data.destination_base_path.rstrip('/')}/"
+                           f"{self.project_path.strip('/')}")
+        # HPC filesystem path (for compute function)
+        fs_root = self.cmd_data.destination_filesystem_root.rstrip('/')
+        dest_fs_dir = f"{fs_root}/{dest_globus_dir.lstrip('/')}"
+
+        batch_id = self._flow_label(group_key, batch)
+        manifest_globus_path = (f"{dest_globus_dir}/LivePreprocess/job001/"
+                                f"Manifests/{batch_id}.json")
+        manifest_path_on_hpc = (f"{dest_fs_dir}/LivePreprocess/job001/"
+                                f"Manifests/{batch_id}.json")
+
+        # Build manifest and write it to the frames directory (same Globus mount)
+        manifest = self._build_manifest(group_key, batch, file_pairs, gain_ref=gain_ref)
+        manifests_dir = self.frames_dir / "manifests"
+        manifests_dir.mkdir(parents=True, exist_ok=True)
+        local_path = manifests_dir / f"{batch_id}.json"
+        local_path.write_text(json.dumps(manifest, indent=2))
+
+        # Add manifest to the same transfer as the frames
+        src_manifest = _container_to_globus_path(
+            str(local_path), self.cmd_data.source_base_path,
+            self.container_frames_root
+        )
+        all_items = [{"source_path": s, "destination_path": d} for s, d in file_pairs]
+        all_items.append({"source_path": src_manifest, "destination_path": manifest_globus_path})
+
+        flow_input = {
+            "source_collection": self.cmd_data.source_collection_id,
+            "destination_collection": self.cmd_data.destination_collection_id,
+            "compute_endpoint": self.cmd_data.globus_compute_endpoint_id,
+            "compute_function": self.cmd_data.globus_compute_function_id,
+            "compute_kwargs": {
+                "manifest_path": manifest_path_on_hpc,
+                "project_dir": dest_fs_dir,
+                "source_collection": self.cmd_data.source_collection_id,
+                "destination_collection": self.cmd_data.destination_collection_id,
+                "source_base_path": self.cmd_data.source_base_path,
+                "destination_base_path": self.cmd_data.destination_base_path,
+                "destination_filesystem_root": self.cmd_data.destination_filesystem_root,
+            },
+            "transfer_items": all_items,
+            "label": label,
+            "results_label": f"Results {label}",
+        }
+
+        run = self.fc.run_flow(body={"input": flow_input}, label=label[:64])
+        run_id = run["run_id"]
+        self._active_flow_runs[run_id] = {"batch": batch, "group_key": group_key}
+        logger.info(f'Flow run started: {run_id} for {label}')
+
+    def _start_transfer_only(self, group_key: str, batch: List, file_pairs: List, label: str = "", gain_ref: str = ""):
+        """Transfer-only mode: just move files to HPC.
+
+        Also writes a manifest for HPC processing
+        if the user starts a Live job manually.
+        """
+        from globus_sdk import TransferData
+
+        td = TransferData(
+            source_endpoint=self.cmd_data.source_collection_id,
+            destination_endpoint=self.cmd_data.destination_collection_id,
+            label=label,
+        )
+        for src, dst in file_pairs:
+            td.add_item(src, dst)
+
+        result = self.tc.submit_transfer(td)
+        task_id = result['task_id']
+        self._active_flow_runs[task_id] = {"batch": batch, "group_key": group_key, "transfer_only": True}
+        logger.info(f'Transfer submitted: {task_id} for {label}')
+
+        # Write manifest (no flow_run_id — no callback expected)
+        manifest = self._build_manifest(group_key, batch, file_pairs, gain_ref=gain_ref)
+        self._transfer_manifest(manifest)
+
+    # ---- Flow run status ----
+
+    def _check_flow_runs(self):
+        """Check status of active flow runs / transfers."""
+        for run_id, info in list(self._active_flow_runs.items()):
+            if info.get("transfer_only"):
+                self._check_transfer(run_id, info)
+            else:
+                self._check_flow(run_id, info)
+
+    def _check_transfer(self, task_id: str, info: dict):
+        task = self.tc.get_task(task_id)
+        if task['status'] == 'SUCCEEDED':
+            logger.info(f'Transfer {task_id} completed for group {info["group_key"]}')
+            del self._active_flow_runs[task_id]
+            self._submitted_groups.discard(info["group_key"])
+        elif task['status'] == 'FAILED':
+            logger.error(f'Transfer {task_id} failed: {task.get("nice_status_details", "")}')
+            del self._active_flow_runs[task_id]
+            self._submitted_groups.discard(info["group_key"])
+
+    def _check_flow(self, run_id: str, info: dict):
+        run = self.fc_general.get_run(run_id)
+        status = run["status"]
+
+        if status == "SUCCEEDED":
+            logger.info(f'Flow run {run_id} completed for group {info["group_key"]}')
+            # Results are in the .done.json transferred back by the flow.
+            # It lands at the Globus destination path on the DTN filesystem.
+            batch_id = self._flow_label(info['group_key'], info.get('batch', []))
+            done_path = (Path(self.container_frames_root) /
+                         "LivePreprocess" / "job001" / "Manifests" /
+                         f"{batch_id}.done.json")
+            if done_path.exists():
+                done_data = json.loads(done_path.read_text())
+                self._update_db_from_done(done_data)
+                self._move_thumbnails(done_data)
+                logger.info(f'Updated DB from {done_path}')
+            else:
+                logger.warning(f'Flow completed but .done.json not found at {done_path}')
+            del self._active_flow_runs[run_id]
+            # Allow resubmission if new images arrived in this group while the flow ran
+            self._submitted_groups.discard(info["group_key"])
+
+        elif status in ("FAILED", "CANCELLED"):
+            logger.error(f'Flow run {run_id} {status} for group {info["group_key"]}')
+            del self._active_flow_runs[run_id]
+            self._submitted_groups.discard(info["group_key"])
+
+    def _sync_thumbnails(self):
+        """Move any thumbnails sitting on the frames mount to the data mount."""
+        import shutil
+        grid_rel = str(self.grid.directory)[len(self.container_data_root):].lstrip('/')
+        frames_pngs = Path(self.container_frames_root) / grid_rel / 'pngs'
+        data_pngs = Path(self.grid.directory) / 'pngs'
+        if not frames_pngs.exists():
+            return
+        data_pngs.mkdir(parents=True, exist_ok=True)
+        count = 0
+        for f in frames_pngs.glob('*.png'):
+            dst = data_pngs / f.name
+            if not dst.exists():
+                shutil.move(str(f), str(dst))
+                count += 1
+        # CTF thumbnails
+        frames_grid = frames_pngs.parent
+        data_grid = Path(self.grid.directory)
+        for d in frames_grid.iterdir():
+            ctf = d / 'ctf.png'
+            if d.is_dir() and ctf.exists():
+                dst = data_grid / d.name / 'ctf.png'
+                if not dst.exists():
+                    dst.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.move(str(ctf), str(dst))
+                    count += 1
+        if count:
+            logger.info(f'Synced {count} thumbnails to {data_pngs}')
+
+    def _move_thumbnails(self, done_data: dict):
+        """Move thumbnails from Globus landing path (frames mount) to SmartScope data dir."""
+        import shutil
+        results = done_data.get('results', [])
+        # Globus transferred to the frames mount at the same relative path as grid.directory
+        # e.g. frames mount: /mnt/arctica/Superluminal/SmartScope/20260316_.../1_Rori_.../pngs/
+        #      data mount:   /mnt/data/Superluminal/20260316_.../1_Rori_.../pngs/
+        grid_rel = str(self.grid.directory)[len(self.container_data_root):].lstrip('/')
+        frames_grid_dir = Path(self.container_frames_root) / grid_rel
+        pngs_dir = Path(self.grid.directory) / 'pngs'
+        pngs_dir.mkdir(parents=True, exist_ok=True)
+        count = 0
+        for mic in results:
+            movie_stem = Path(mic.get('movie_path', mic.get('movie', ''))).stem
+            hm_name = self._find_hm_name_for_movie(movie_stem)
+            if not hm_name:
+                continue
+            # Micrograph thumbnail
+            src = frames_grid_dir / 'pngs' / f'{hm_name}.png'
+            dst = pngs_dir / f'{hm_name}.png'
+            if src.exists():
+                shutil.move(str(src), str(dst))
+                count += 1
+            # CTF thumbnail
+            src = frames_grid_dir / hm_name / 'ctf.png'
+            dst = Path(self.grid.directory) / hm_name / 'ctf.png'
+            if src.exists():
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                shutil.move(str(src), str(dst))
+                count += 1
+        if count:
+            logger.info(f'Moved {count} thumbnails to {pngs_dir}')
+
+    # ---- Results polling & DB updates ----
+
+    def _find_hm_name_for_movie(self, movie_stem: str) -> str:
+        """Find the HighMagModel name that corresponds to a movie filename stem."""
+        hm = (HighMagModel.parent_manager
+              .filter(grid_id=self.grid.pk, frames__endswith=f'{movie_stem}.tif')
+              .values_list('name', flat=True)
+              .first())
+        if hm:
+            return hm
+        # Try other extensions
+        hm = (HighMagModel.parent_manager
+              .filter(grid_id=self.grid.pk, frames__contains=movie_stem)
+              .values_list('name', flat=True)
+              .first())
+        return hm or ''
+
+    def _update_db_from_done(self, done_data: dict):
+        """Update HighMagModel + HoleModel from a .done.json file."""
+        from django.utils import timezone
+        from django.contrib.contenttypes.models import ContentType
+
+        results = done_data.get('results', [])
+        pixel_size = self.cmd_data.extra_config.get('pixel_size', 0) or (
+            float(self.detector.pixel_size) if hasattr(self.detector, 'pixel_size')
+            and self.detector.pixel_size else 1.0
+        )
+
+        highmags_to_update = []
+        holes_to_update = []
+        selectors_to_create = []
+        hole_content_type = ContentType.objects.get_for_model(HoleModel)
+        selector_hole_pks = set()
+
+        for mic in results:
+            movie_stem = Path(mic.get('movie_path', mic.get('movie', ''))).stem
+            hm_name = self._find_hm_name_for_movie(movie_stem)
+            if not hm_name:
+                logger.warning(f'No HighMagModel found for movie {movie_stem}')
+                continue
+
+            try:
+                hm = HighMagModel.objects.get(name=hm_name)
+            except HighMagModel.DoesNotExist:
+                logger.warning(f'HighMagModel {hm_name} not in DB')
+                continue
+
+            defocus_u = mic.get('defocus_u', 0.0)
+            defocus_v = mic.get('defocus_v', 0.0)
+
+            hm.defocus = (defocus_u + defocus_v) / 2.0
+            hm.astig = abs(defocus_u - defocus_v)
+            hm.angast = mic.get('defocus_angle', 0.0)
+            hm.ctffit = mic.get('ctf_max_resolution', 999.0)
+            hm.ice_thickness = int(round(mic.get('ice_thickness', 0.0) / 10))
+            hm.shape_x = mic.get('shape_x', 0) or 0
+            hm.shape_y = mic.get('shape_y', 0) or 0
+            hm.pixel_size = pixel_size
+            hm.status = 'completed'
+            hm.completion_time = timezone.now()
+            highmags_to_update.append(hm)
+
+            if hm.hole_id:
+                hm.hole_id.status = 'completed'
+                hm.hole_id.completion_time = timezone.now()
+                holes_to_update.append(hm.hole_id)
+
+            # Compute mean_pick_score from coordinates if available
+            coords = mic.get('coordinates', [])
+            if coords:
+                scores = [c[2] for c in coords if len(c) > 2]
+                mic['mean_pick_score'] = sum(scores) / len(scores) if scores else 0.0
+            else:
+                mic['mean_pick_score'] = 0.0
+
+            # Create Selector records on the parent hole for each mapped result field
+            if hm.hole_id:
+                hole_pk = hm.hole_id.pk
+                selector_hole_pks.add(hole_pk)
+                for result_key, method_name in RESULT_SELECTORS.items():
+                    value = mic.get(result_key)
+                    if value is not None:
+                        selectors_to_create.append(Selector(
+                            content_type=hole_content_type,
+                            object_id=hole_pk,
+                            method_name=method_name,
+                            value=float(value),
+                        ))
+
+        if highmags_to_update or holes_to_update:
+            with transaction.atomic():
+                if highmags_to_update:
+                    HighMagModel.objects.bulk_update(
+                        highmags_to_update,
+                        fields=['status', 'defocus', 'astig', 'angast', 'ctffit',
+                                'ice_thickness', 'shape_x', 'shape_y', 'pixel_size',
+                                'completion_time']
+                    )
+                if holes_to_update:
+                    HoleModel.objects.bulk_update(
+                        holes_to_update,
+                        fields=['status', 'completion_time']
+                    )
+                if selectors_to_create:
+                    # Remove existing selectors for these holes/methods to avoid duplicates
+                    Selector.objects.filter(
+                        content_type=hole_content_type,
+                        object_id__in=list(selector_hole_pks),
+                        method_name__in=RESULT_SELECTORS.values(),
+                    ).delete()
+                    Selector.objects.bulk_create(selectors_to_create)
+                    logger.info(f"Created {len(selectors_to_create)} selectors for "
+                                f"{len(selector_hole_pks)} holes")
+
+            all_updated = highmags_to_update + holes_to_update
+            websocket_update(all_updated, self.grid.grid_id)
+            logger.info(f"Updated {len(highmags_to_update)} high-mag images, "
+                         f"{len(holes_to_update)} holes from preprocessing results")
+
+    def check_for_update(self, instance):
+        pass
+
+    # ---- Shutdown ----
+
+    def stop(self):
+        logger.info('Stopping Globus preprocessing pipeline')
+        self._stop.set()

--- a/Smartscope/core/pipelines/schemas/compute_function.schema.json
+++ b/Smartscope/core/pipelines/schemas/compute_function.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SmartScope Compute Function Return Value",
+  "description": "The Globus Compute function must return this object. The flow uses transfer_items to transfer results back to the SmartScope side.",
+  "type": "object",
+  "required": ["status", "batch_id", "transfer_items"],
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": ["completed", "failed"]
+    },
+    "batch_id": {
+      "type": "string"
+    },
+    "transfer_items": {
+      "type": "array",
+      "description": "Globus transfer items for the results-back step. Must include at least the .done.json file. Thumbnails should use the paths from manifest.thumbnail_destinations.",
+      "items": {
+        "type": "object",
+        "required": ["source_path", "destination_path"],
+        "properties": {
+          "source_path": {
+            "type": "string",
+            "description": "Globus collection path on the HPC side."
+          },
+          "destination_path": {
+            "type": "string",
+            "description": "Globus collection path on the SmartScope side."
+          }
+        }
+      }
+    }
+  }
+}

--- a/Smartscope/core/pipelines/schemas/manifest.schema.json
+++ b/Smartscope/core/pipelines/schemas/manifest.schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SmartScope Preprocessing Manifest",
+  "description": "Sent by SmartScope to the compute function via the manifest JSON file. Describes a batch of movies to preprocess.",
+  "type": "object",
+  "required": ["batch_id", "movies", "config"],
+  "properties": {
+    "batch_id": {
+      "type": "string",
+      "description": "Unique identifier for this batch (used for output filenames)."
+    },
+    "flow_run_id": {
+      "type": "string",
+      "description": "Globus Flow run ID (informational)."
+    },
+    "grid_id": {
+      "type": "string",
+      "description": "SmartScope grid identifier (informational)."
+    },
+    "movies": {
+      "type": "array",
+      "description": "Movie file paths relative to project_dir.",
+      "items": { "type": "string" }
+    },
+    "config": {
+      "type": "object",
+      "description": "Processing parameters. Compute functions should use these to configure their pipeline.",
+      "properties": {
+        "project_dir": {
+          "type": "string",
+          "description": "Absolute path to the project directory on the HPC."
+        },
+        "output_dir": {
+          "type": "string",
+          "description": "Absolute path for processing output."
+        },
+        "pixel_size": {
+          "type": "number",
+          "description": "Pixel size in Angstroms/pixel."
+        },
+        "voltage": {
+          "type": "integer",
+          "description": "Accelerating voltage in kV (e.g. 200, 300)."
+        },
+        "cs": {
+          "type": "number",
+          "description": "Spherical aberration in mm."
+        },
+        "dose_per_frame": {
+          "type": "number",
+          "description": "Electron dose per frame in e/A^2."
+        },
+        "gain_reference": {
+          "type": "string",
+          "description": "Gain reference filename (in project root). Empty if none."
+        },
+        "gain_rotation": {
+          "type": "integer",
+          "description": "Gain reference rotation (0-3, RELION convention)."
+        },
+        "gain_flip": {
+          "type": "integer",
+          "description": "Gain reference flip (0 or 1, RELION convention)."
+        },
+        "do_motioncor": { "type": "boolean" },
+        "do_ctf": { "type": "boolean" },
+        "do_miffi": { "type": "boolean" },
+        "do_picking": { "type": "boolean" },
+        "do_extraction": { "type": "boolean" },
+        "motioncor_binning": { "type": "number" },
+        "motioncor_patches": { "type": "integer" },
+        "picking_threshold": { "type": "number" },
+        "picking_model": { "type": "string" },
+        "box_size": { "type": "integer" },
+        "extract_box_size": { "type": "integer" },
+        "extract_downscale": { "type": "integer" }
+      }
+    },
+    "thumbnail_destinations": {
+      "type": "object",
+      "description": "Map of movie filename -> Globus destination paths for thumbnails. The compute function uses these in its transfer_items to route thumbnails directly to where SmartScope expects them.",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "png": { "type": "string", "description": "Globus path for the micrograph thumbnail." },
+          "ctf": { "type": "string", "description": "Globus path for the CTF thumbnail." }
+        }
+      }
+    }
+  }
+}

--- a/Smartscope/core/pipelines/schemas/results.schema.json
+++ b/Smartscope/core/pipelines/schemas/results.schema.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SmartScope Preprocessing Results (.done.json)",
+  "description": "Written by the compute function after processing. SmartScope reads this to update its database. Must be included in the function's transfer_items so it is transferred back.",
+  "type": "object",
+  "required": ["status", "batch_id", "results"],
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": ["completed", "failed"],
+      "description": "Overall batch status."
+    },
+    "batch_id": {
+      "type": "string",
+      "description": "Must match the batch_id from the manifest."
+    },
+    "error": {
+      "type": "string",
+      "description": "Error message (when status is 'failed')."
+    },
+    "results": {
+      "type": "array",
+      "description": "Per-micrograph results. One entry per successfully processed movie.",
+      "items": {
+        "type": "object",
+        "required": ["movie_path"],
+        "properties": {
+          "movie_path": {
+            "type": "string",
+            "description": "Movie filename (used to match back to SmartScope's HighMagModel). Can be relative or absolute; SmartScope matches on the filename stem."
+          },
+          "defocus_u": {
+            "type": "number",
+            "description": "Defocus U in Angstroms."
+          },
+          "defocus_v": {
+            "type": "number",
+            "description": "Defocus V in Angstroms."
+          },
+          "defocus_angle": {
+            "type": "number",
+            "description": "Defocus angle in degrees."
+          },
+          "ctf_max_resolution": {
+            "type": "number",
+            "description": "CTF fit resolution in Angstroms (lower is better). SmartScope displays this as 'CTF resolution'."
+          },
+          "total_motion": {
+            "type": "number",
+            "description": "Total beam-induced motion in Angstroms."
+          },
+          "ice_thickness": {
+            "type": "number",
+            "description": "Estimated ice thickness in Angstroms. SmartScope converts to nm (divides by 10)."
+          },
+          "particle_count": {
+            "type": "integer",
+            "description": "Number of picked particles."
+          },
+          "coordinates": {
+            "type": "array",
+            "description": "Picked particle coordinates as [x, y, score] arrays. SmartScope computes mean_pick_score from the scores.",
+            "items": {
+              "type": "array",
+              "items": { "type": "number" }
+            }
+          },
+          "shape_x": {
+            "type": "integer",
+            "description": "Micrograph width in pixels."
+          },
+          "shape_y": {
+            "type": "integer",
+            "description": "Micrograph height in pixels."
+          },
+          "thumbnail": {
+            "type": "string",
+            "description": "Path to micrograph thumbnail PNG, relative to output_dir."
+          },
+          "ctf_thumbnail": {
+            "type": "string",
+            "description": "Path to CTF fit thumbnail PNG, relative to output_dir."
+          }
+        }
+      }
+    }
+  }
+}

--- a/Smartscope/core/preprocessing_pipelines.py
+++ b/Smartscope/core/preprocessing_pipelines.py
@@ -10,13 +10,14 @@ from Smartscope.lib.logger import add_log_handlers
 
 logger = logging.getLogger(__name__)
 
-from .pipelines import PreprocessingPipelineCmd, SmartscopePreprocessingPipeline, CryoSPARCPipeline, NextPYPPreprocessingPipeline, NextPYPPreprocessingCmdKwargs
+from .pipelines import PreprocessingPipelineCmd, SmartscopePreprocessingPipeline, CryoSPARCPipeline, NextPYPPreprocessingPipeline, NextPYPPreprocessingCmdKwargs, GlobusPreprocessingPipeline
 
 
 PREPROCESSING_PIPELINE_FACTORY = {
     "smartscopePipeline" : SmartscopePreprocessingPipeline,
     # "cryoSPARC" : CryoSPARCPipeline,
     "nextpypPipeline" : NextPYPPreprocessingPipeline,
+    "globusPipeline" : GlobusPreprocessingPipeline,
 }
 
 def load_preprocessing_pipeline(file:Path):
@@ -38,8 +39,8 @@ def load_preprocessing_pipeline(file:Path):
     #         )
     #         return data
     # logger.info(f'nextPYP preprocessing pipeline not found.')
-    return None 
-    
+    return None
+
 
 def highmag_processing(grid_id: str, *args, **kwargs) -> None:
     try:

--- a/Smartscope/core/selector_sorter.py
+++ b/Smartscope/core/selector_sorter.py
@@ -96,7 +96,7 @@ class SelectorValueParser:
         return next(filter(lambda x: x.method_name == self._selector_name ,target.selectors)).value
     
     def get_selector_value_from_server(self,target):
-        return next(filter(lambda x: x.method_name == self._selector_name ,target.selectors.all())).value
+        return next((x.value for x in target.selectors.all() if x.method_name == self._selector_name), None)
     
     def extract_values(self, targets:List[models.Target]) -> List[float]:
         values = list(map(self.get_selector_value,targets))
@@ -159,12 +159,23 @@ class SelectorSorter:
         self._classes = None
 
     @property
+    def _valid_values(self) -> List[float]:
+        return [v for v in self.values if v is not None]
+
+    @property
     def values_range(self) -> List[float]:
-        return [floor(min(self.values)), ceil(max(self.values))]
+        valid = self._valid_values
+        if not valid:
+            return [0, 0]
+        return [floor(min(valid)), ceil(max(valid))]
 
     def set_limits(self):
-        range_ = max(self.values) - min(self.values)
-        self._limits = np.array(self._fractional_limits) * range_ + min(self.values)
+        valid = self._valid_values
+        if not valid:
+            self._limits = [0.0, 1.0]
+            return
+        range_ = max(valid) - min(valid)
+        self._limits = np.array(self._fractional_limits) * range_ + min(valid)
 
     def set_labels(self):
         logger.debug(f'Getting colored classes from selector {self.selector_name}. Inputs {len(self.values)} targets and {self._n_classes} classes with {self.limits} limits.')
@@ -183,7 +194,7 @@ class SelectorSorter:
         
         # for value, in_bounds in zip(values, map_in_bounds):
         def get_class(value, in_bounds) -> int:
-            if not in_bounds:
+            if not in_bounds or value is None:
                 return 0
             if value == self.limits[1]:
                 return self._n_classes
@@ -203,7 +214,8 @@ class SelectorSorter:
         if self.limits is None:
             self.set_limits()
         def selector_value_within_limits(target_value):
-            # logger.debug(f'Checking if {target_value} is within {self.limits}')
+            if target_value is None:
+                return False
             return self.limits[0] <= target_value <= self.limits[1]
 
         selector_value_within_limits = map(selector_value_within_limits,self.values)

--- a/Smartscope/server/frontend/templates/smartscopeSetup/preprocessing/preprocessing_pipeline.html
+++ b/Smartscope/server/frontend/templates/smartscopeSetup/preprocessing/preprocessing_pipeline.html
@@ -3,11 +3,12 @@
 
 {% block sidebar_content %}
 <div class="col justify-content-center">
-    <form   method="get" 
+    <form   method="get"
             hx-get="{% url 'getPreprocessingPipeline' %}"
             hx-target="#preprocessingPipelineForm"
             hx-indicator="#spinner"
-            hx-trigger="change">
+            hx-trigger="change"
+            {% if grid %}hx-vals='{"grid_id": "{{ grid.grid_id }}"}'{% endif %}>
         {% include "forms/formFieldsBase.html" with form=form row=false %}
         <div id="spinner" class="my-indicator spinner-border text-primary" role="status">
             <span class="sr-only"></span>

--- a/Smartscope/server/frontend/views/views.py
+++ b/Smartscope/server/frontend/views/views.py
@@ -445,7 +445,7 @@ class PreprocessingPipeline(TemplateView):
             context['pipeline'] = pipeline
             context['description'] = pipeline_obj.description
             context['form'] = pipeline_obj.form()
-            # context['grid_id'] = None
+            context['grid_id'] = request.GET.get('grid_id', '')
             return TemplateResponse(request=request,template="smartscopeSetup/preprocessing/preprocessing_pipeline_form.html",context=context)
         except Exception as err:
             logger.exception(err)
@@ -463,14 +463,17 @@ class PreprocessingPipeline(TemplateView):
                     logger.debug(pipeline_data)
                     return TemplateResponse(request=request,
                                             template='forms/formFieldsBase.html',
-                                            context=dict(form=PreprocessingPipelineIDForm(data=dict(preprocessing_pipeline_id=pipeline_data.cache_id)), 
-                                                                                        row=True, 
+                                            context=dict(form=PreprocessingPipelineIDForm(data=dict(preprocessing_pipeline_id=pipeline_data.cache_id)),
+                                                                                        row=True,
                                                                                         id='formPreprocess'))
                 context = self.get_grid_context_data(grid_id)
                 pipeline_data.process_pid = context['pipeline_data'].process_pid
                 Path(context['grid'].directory,'preprocessing.json').write_text(pipeline_data.json(exclude={'cache_id'}))
                 logger.info('Updated pipeline for existing grid')
                 return self.get_grid_pipeline(request, grid_id=grid_id)
+            else:
+                logger.warning(f'Form validation failed: {form.errors}')
+                return HttpResponse(f'Form validation failed: {form.errors}', status=400)
         except Exception as err:
             logger.exception(err)
 

--- a/config/smartscope/plugins/preprocessing_ctf_resolution.yaml
+++ b/config/smartscope/plugins/preprocessing_ctf_resolution.yaml
@@ -1,0 +1,10 @@
+name: CTF resolution
+targetClass:
+  - Selector
+description: |
+  CTF fit resolution in Angstroms from the preprocessing pipeline. Lower is better.
+clusters:
+  values: ascending
+  colors: ['darkgreen', 'green', 'lightgreen', 'yellow', 'orange', 'red']
+exclude: []
+limits: [0.0, 1.0]

--- a/config/smartscope/plugins/preprocessing_ice_thickness.yaml
+++ b/config/smartscope/plugins/preprocessing_ice_thickness.yaml
@@ -1,0 +1,10 @@
+name: Ice thickness
+targetClass:
+  - Selector
+description: |
+  Estimated ice thickness from the preprocessing pipeline.
+clusters:
+  values: ascending
+  colors: ['blue', 'lightblue', 'CornflowerBlue', 'blueviolet', 'purple', 'white']
+exclude: ['0']
+limits: [0.0, 1.0]

--- a/config/smartscope/plugins/preprocessing_particle_count.yaml
+++ b/config/smartscope/plugins/preprocessing_particle_count.yaml
@@ -1,0 +1,10 @@
+name: Particle count
+targetClass:
+  - Selector
+description: |
+  Number of particles picked per micrograph by the preprocessing pipeline.
+clusters:
+  values: ascending
+  colors: ['red', 'orange', 'yellow', 'lightgreen', 'green', 'darkgreen']
+exclude: ['0']
+limits: [0.0, 1.0]

--- a/config/smartscope/plugins/preprocessing_pick_score.yaml
+++ b/config/smartscope/plugins/preprocessing_pick_score.yaml
@@ -1,0 +1,10 @@
+name: Pick score
+targetClass:
+  - Selector
+description: |
+  Mean particle picking confidence score per micrograph from the preprocessing pipeline.
+clusters:
+  values: ascending
+  colors: ['red', 'orange', 'yellow', 'lightgreen', 'green', 'darkgreen']
+exclude: ['0']
+limits: [0.0, 1.0]

--- a/config/smartscope/plugins/preprocessing_total_motion.yaml
+++ b/config/smartscope/plugins/preprocessing_total_motion.yaml
@@ -1,0 +1,10 @@
+name: Total motion
+targetClass:
+  - Selector
+description: |
+  Total beam-induced motion in Angstroms from the preprocessing pipeline. Lower is better.
+clusters:
+  values: ascending
+  colors: ['darkgreen', 'green', 'lightgreen', 'yellow', 'orange', 'red']
+exclude: []
+limits: [0.0, 1.0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["black", "flake8"]
+globus = ["globus-sdk>=3.0", "globus-compute-sdk>=2.0"]
 
 [project.urls]
 Homepage = "https://smartscope.org"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,6 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["black", "flake8"]
-globus = ["globus-sdk>=3.0", "globus-compute-sdk>=2.0"]
 
 [project.urls]
 Homepage = "https://smartscope.org"

--- a/scripts/compute_function_template.py
+++ b/scripts/compute_function_template.py
@@ -1,0 +1,127 @@
+"""SmartScope Compute Function Template.
+
+Copy this file, implement run_preprocessing(), and register it:
+
+    python setup_globus.py register-func --function my_function.py
+
+Your function will be serialized by Globus Compute and run on the HPC.
+It must be self-contained — all imports must happen inside the function
+body, since only the function code is sent to the remote endpoint.
+
+Contract:
+    Input:  manifest_path (str) — path to manifest JSON on HPC
+            project_dir (str) — absolute path to project directory on HPC
+            + Globus path kwargs (source_collection, destination_collection, etc.)
+    Output: dict with "status", "batch_id", and "transfer_items"
+
+See schemas/ for the full manifest and results JSON schemas.
+"""
+
+
+def run_preprocessing(manifest_path: str, project_dir: str,
+                      source_collection: str = "", destination_collection: str = "",
+                      source_base_path: str = "", destination_base_path: str = "",
+                      destination_filesystem_root: str = "") -> dict:
+    """Process a batch of movies on the HPC.
+
+    This function is serialized by Globus Compute. Everything it needs
+    must be imported inside the function body.
+    """
+    import json
+    import subprocess
+    from pathlib import Path
+
+    # ---- Read manifest ----
+    manifest = json.loads(Path(manifest_path).read_text())
+    batch_id = manifest.get("batch_id", "unknown")
+    config = manifest.get("config", {})
+    movies = [m for m in manifest.get("movies", [])
+              if m.lower().endswith((".tif", ".tiff", ".mrc", ".eer"))]
+
+    if not movies:
+        return {"status": "completed", "batch_id": batch_id,
+                "transfer_items": []}
+
+    # ---- Your processing logic here ----
+    #
+    # config contains:
+    #   project_dir, output_dir    — paths on the HPC
+    #   pixel_size, voltage, cs    — microscope parameters (auto-populated by SmartScope)
+    #   gain_reference             — gain ref filename (in project root)
+    #   gain_rotation, gain_flip   — gain ref orientation (RELION convention)
+    #   + any extra_config keys from the SmartScope form
+    #
+    # Example: submit a SLURM job, run a container, call a CLI tool, etc.
+    #
+    # results = run_my_pipeline(movies, config)
+
+    # ---- Build results ----
+    # Each entry corresponds to one processed movie.
+    # SmartScope matches on the movie filename stem.
+    results = []
+    for movie in movies:
+        results.append({
+            "movie_path": movie,
+            # CTF results (Angstroms)
+            "defocus_u": 0.0,
+            "defocus_v": 0.0,
+            "defocus_angle": 0.0,
+            "ctf_max_resolution": 999.0,
+            # Motion (Angstroms)
+            "total_motion": 0.0,
+            # Ice thickness (Angstroms — SmartScope converts to nm)
+            "ice_thickness": 0.0,
+            # Picking
+            "particle_count": 0,
+            "coordinates": [],  # [[x, y, score], ...]
+            # Micrograph dimensions
+            "shape_x": 0,
+            "shape_y": 0,
+            # Thumbnail paths relative to output_dir (optional)
+            "thumbnail": "",
+            "ctf_thumbnail": "",
+        })
+
+    # ---- Write .done.json ----
+    # SmartScope reads this file to update its database.
+    output_dir = Path(config.get("output_dir",
+                      str(Path(project_dir) / "LivePreprocess" / "job001")))
+    done_file = output_dir / f"Manifests/{batch_id}.done.json"
+    done_file.parent.mkdir(parents=True, exist_ok=True)
+    done_file.write_text(json.dumps({
+        "status": "completed",
+        "batch_id": batch_id,
+        "results": results,
+    }, indent=2))
+
+    # ---- Build transfer items ----
+    # These tell the Globus Flow what to transfer back to SmartScope.
+    # At minimum, include the .done.json file.
+    fs_root = destination_filesystem_root.rstrip("/")
+    hpc_globus_base = "/" + project_dir.replace(fs_root, "").strip("/")
+    done_rel = str(done_file).replace(project_dir, "").strip("/")
+
+    transfer_items = [{
+        "source_path": f"{hpc_globus_base}/{done_rel}",
+        "destination_path": f"{source_base_path}/{done_rel}",
+    }]
+
+    # Add thumbnails using destinations from the manifest
+    thumb_dests = manifest.get("thumbnail_destinations", {})
+    job_rel = str(output_dir).replace(project_dir, "").strip("/")
+    for mic in results:
+        movie_name = Path(mic.get("movie_path", "")).name
+        dests = thumb_dests.get(movie_name, {})
+        if mic.get("thumbnail") and dests.get("png"):
+            transfer_items.append({
+                "source_path": f"{hpc_globus_base}/{job_rel}/{mic['thumbnail']}",
+                "destination_path": dests["png"],
+            })
+        if mic.get("ctf_thumbnail") and dests.get("ctf"):
+            transfer_items.append({
+                "source_path": f"{hpc_globus_base}/{job_rel}/{mic['ctf_thumbnail']}",
+                "destination_path": dests["ctf"],
+            })
+
+    return {"status": "completed", "batch_id": batch_id,
+            "transfer_items": transfer_items}

--- a/scripts/register_compute_function.py
+++ b/scripts/register_compute_function.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Register the SmartScope Globus Compute function using existing tokens.
+
+Usage:
+    docker exec smartscope-smartscope-1 python /opt/smartscope/scripts/register_compute_function.py
+"""
+
+import json
+from pathlib import Path
+from globus_sdk import NativeAppAuthClient, ComputeClientV2, RefreshTokenAuthorizer
+from globus_compute_sdk.sdk.client import FunctionRegistrationData
+
+
+def run_preprocessing(manifest_path: str, project_dir: str,
+                    source_collection: str = "", destination_collection: str = "",
+                    source_base_path: str = "", destination_base_path: str = "",
+                    destination_filesystem_root: str = "") -> dict:
+    """Run preprocessing for a batch of movies via SLURM.
+
+    Called by Globus Compute on the HPC. Writes a SLURM batch script
+    that runs the staged pipeline (motioncor -> CTF -> picking ->
+    extraction -> finalize), submits it, waits for completion, reads
+    results from the STAR file, and returns transfer items.
+    """
+    import json as _json
+    import os
+    import subprocess
+    import time
+    from pathlib import Path as _Path
+
+    manifest = _json.loads(_Path(manifest_path).read_text())
+    batch_id = manifest.get('batch_id', 'unknown')
+    config = manifest.get('config', {})
+
+    # Filter to only movie files (not .mdoc etc)
+    movies = [m for m in manifest.get('movies', [])
+              if m.lower().endswith(('.tif', '.tiff', '.mrc', '.eer'))]
+
+    if not movies:
+        return {'status': 'completed', 'batch_id': batch_id,
+                'results': [], 'transfer_items': []}
+
+    # --- Set up job directory ---
+    job_dir = _Path(config.get('output_dir',
+                    str(_Path(project_dir) / 'LivePreprocess' / 'job001')))
+    for subdir in ['MotionCorr/Micrographs', 'MotionCorr/Motion',
+                   'CtfFind/Micrographs', 'MiFFI', 'AutoPick/Micrographs',
+                   'Thumbnails', 'CtfThumbnails', 'batches',
+                   'Extract/Particles']:
+        (job_dir / subdir).mkdir(parents=True, exist_ok=True)
+
+    # Write config
+    config_data = {
+        'output_dir': str(job_dir),
+        'project_dir': project_dir,
+        'pixel_size': config.get('pixel_size', 1.0),
+        'voltage': config.get('voltage', 300),
+        'cs': config.get('cs', 2.7),
+        'amplitude_contrast': config.get('amplitude_contrast', 0.07),
+        'dose_per_frame': config.get('dose_per_frame', 1.0),
+        'gain_reference': config.get('gain_reference', ''),
+        'gain_rotation': config.get('gain_rotation', 0),
+        'gain_flip': config.get('gain_flip', 0),
+        'motioncor_patches': config.get('motioncor_patches', 5),
+        'motioncor_binning': config.get('motioncor_binning', 1.0),
+        'ctf_backend': config.get('ctf_backend', 'ctffind5'),
+        'ctf_box_size': config.get('ctf_box_size', 512),
+        'defocus_min': config.get('defocus_min', 5000.0),
+        'defocus_max': config.get('defocus_max', 50000.0),
+        'do_picking': config.get('do_picking', True),
+        'picking_threshold': config.get('picking_threshold', 0.3),
+        'picking_model': config.get('picking_model', ''),
+        'box_size': config.get('box_size', 200),
+        'do_extract': config.get('do_extraction', False),
+        'extract_box_size': config.get('extract_box_size', 256),
+        'extract_downscale': config.get('extract_downscale', 1),
+        'thumbnail_size': config.get('thumbnail_size', 1024),
+    }
+    config_path = job_dir / 'batches' / f'{batch_id}_config.json'
+    config_path.write_text(_json.dumps(config_data, indent=2))
+
+    # Write movies file
+    movies_file = job_dir / 'batches' / f'{batch_id}_movies.txt'
+    movies_file.write_text('\n'.join(movies) + '\n')
+
+    # --- Build staged SLURM script ---
+    batches_dir = job_dir / 'batches'
+    mc_results = batches_dir / f'{batch_id}_mc.json'
+    ctf_results = batches_dir / f'{batch_id}_ctf.json'
+    pick_results = batches_dir / f'{batch_id}_pick.json'
+    extract_results = batches_dir / f'{batch_id}_extract.json'
+
+    doppio_bin = config.get('doppio_bin', '/home/group/superluminal/software/moduleapps/ccp/doppio/stable/bin')
+    motioncor_module = config.get('motioncor_module', 'motioncor3/1.2.4')
+    ctf_module = config.get('ctf_module', 'ctffind/5.0.2')
+    picking_module = config.get('picking_module', 'cryolo/stable')
+    worker_partition = config.get('worker_partition', 'gpupriority')
+    worker_account = config.get('worker_account', 'priority-superluminal')
+    worker_time = config.get('worker_time_limit', '24:00:00')
+    worker_mem = config.get('worker_mem', '32G')
+
+    stages = []
+
+    # Motion correction
+    stages.append(('motioncor', motioncor_module,
+        f'doppio-live-stage-motioncor --config {config_path} '
+        f'--movies-file {movies_file} --output-file {mc_results}'))
+
+    # CTF
+    ctf_backend = config.get('ctf_backend', 'ctffind5')
+    if ctf_backend == 'motioncor3':
+        stages.append(('ctf', None, f'cp {mc_results} {ctf_results}'))
+    else:
+        stages.append(('ctf', ctf_module,
+            f'doppio-live-stage-ctf --config {config_path} '
+            f'--input-file {mc_results} --output-file {ctf_results}'))
+
+    # Picking
+    picking_input = ctf_results
+    if config.get('do_picking', True):
+        stages.append(('picking', picking_module,
+            f'doppio-live-stage-picking --config {config_path} '
+            f'--input-file {picking_input} --output-file {pick_results}'))
+    else:
+        stages.append(('picking', None, f'cp {picking_input} {pick_results}'))
+
+    # Extraction
+    if config.get('do_extraction', False) and config.get('do_picking', True):
+        stages.append(('extraction', None,
+            f'doppio-live-stage-extraction --config {config_path} '
+            f'--input-file {pick_results} --output-file {extract_results}'))
+    else:
+        stages.append(('extraction', None, f'cp {pick_results} {extract_results}'))
+
+    # Finalize
+    stages.append(('finalize', None,
+        f'doppio-live-stage-finalize --config {config_path} '
+        f'--input-file {extract_results}'))
+
+    # Build script
+    script_file = batches_dir / f'{batch_id}.sh'
+    combined_log = batches_dir / f'{batch_id}.log'
+
+    lines = [
+        '#!/bin/bash',
+        f'#SBATCH --job-name=SmartScope_{batch_id}',
+        f'#SBATCH --partition={worker_partition}',
+        '#SBATCH --gres=gpu:1',
+        '#SBATCH --cpus-per-task=4',
+        f'#SBATCH --mem={worker_mem}',
+        f'#SBATCH --time={worker_time}',
+        f'#SBATCH --output={combined_log}',
+        f'#SBATCH --error={combined_log}',
+    ]
+    if worker_account:
+        lines.append(f'#SBATCH --account={worker_account}')
+    constraint = config.get('worker_constraint', 'a40|a100')
+    if constraint:
+        lines.append(f'#SBATCH --constraint="{constraint}"')
+    lines.append(f'\ncd {project_dir}')
+
+    for stage_name, tool_module, command in stages:
+        stage_log = batches_dir / f'{batch_id}_{stage_name}.log'
+        lines.append(f'\n# === Stage: {stage_name} ===')
+        if tool_module:
+            lines.append('source /etc/profile.d/modules.sh')
+            lines.append('module purge')
+            lines.append(f'module load {tool_module}')
+        lines.append(f'export PATH="{doppio_bin}:$PATH"')
+        lines.append(f'{command} >> {stage_log} 2>&1 || exit 1')
+
+    script_file.write_text('\n'.join(lines) + '\n')
+    script_file.chmod(0o755)
+
+    # --- Submit and wait ---
+    result = subprocess.run(
+        ['sbatch', '--parsable', str(script_file)],
+        capture_output=True, text=True, cwd=project_dir,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f'sbatch failed: {result.stderr}')
+
+    slurm_job_id = result.stdout.strip()
+
+    # Poll for SLURM job completion
+    state = 'UNKNOWN'
+    timeout = 3600
+    poll_interval = 10
+    elapsed = 0
+    while elapsed < timeout:
+        time.sleep(poll_interval)
+        elapsed += poll_interval
+        check = subprocess.run(
+            ['sacct', '-j', slurm_job_id, '--format=State', '--noheader', '-P'],
+            capture_output=True, text=True,
+        )
+        states = [s.strip() for s in check.stdout.strip().split('\n') if s.strip()]
+        if not states:
+            continue
+        state = states[0]
+        if state in ('COMPLETED', 'FAILED', 'CANCELLED', 'TIMEOUT', 'NODE_FAIL'):
+            break
+
+    if state != 'COMPLETED':
+        raise RuntimeError(f'SLURM job {slurm_job_id} ended with state: {state}')
+
+    # --- Read results from finalize output ---
+    # The finalize stage writes updated results (with shape, thumbnails, etc.)
+    # back to the extract_results JSON file.
+    extract_results = batches_dir / f'{batch_id}_extract.json'
+    results = []
+    if extract_results.exists():
+        results = _json.loads(extract_results.read_text())
+
+    # Build Globus transfer items using thumbnail_destinations from manifest
+    fs_root = destination_filesystem_root.rstrip('/')
+    hpc_globus_base = '/' + project_dir.replace(fs_root, '').strip('/')
+    # Thumbnail paths from finalize are relative to job_dir, not project_dir
+    job_rel = str(job_dir).replace(project_dir, '').strip('/')
+    thumb_dests = manifest.get('thumbnail_destinations', {})
+
+    transfer_items = []
+    for mic in results:
+        movie_name = _Path(mic.get('movie_path', mic.get('movie', ''))).name
+        dests = thumb_dests.get(movie_name, {})
+        thumb = mic.get('thumbnail', '')
+        if thumb and dests.get('png'):
+            transfer_items.append({
+                'source_path': f'{hpc_globus_base}/{job_rel}/{thumb}',
+                'destination_path': dests['png'],
+            })
+        ctf_thumb = mic.get('ctf_thumbnail', '')
+        if ctf_thumb and dests.get('ctf'):
+            transfer_items.append({
+                'source_path': f'{hpc_globus_base}/{job_rel}/{ctf_thumb}',
+                'destination_path': dests['ctf'],
+            })
+
+    # Write results to .done.json — keeps metadata out of the flow state
+    done_file = job_dir / f'Manifests/{batch_id}.done.json'
+    done_file.parent.mkdir(parents=True, exist_ok=True)
+    done_file.write_text(_json.dumps({
+        'status': 'completed',
+        'batch_id': batch_id,
+        'results': results,
+    }, indent=2))
+    done_rel = str(done_file).replace(project_dir, '').strip('/')
+    transfer_items.append({
+        'source_path': f'{hpc_globus_base}/{done_rel}',
+        'destination_path': f'{source_base_path}/{done_rel}',
+    })
+
+    # Ensure at least one transfer item (flow requires non-empty DATA)
+    if not transfer_items:
+        log_rel = str(combined_log).replace(project_dir, '').strip('/')
+        transfer_items.append({
+            'source_path': f'{hpc_globus_base}/{log_rel}',
+            'destination_path': f'{source_base_path}/{log_rel}',
+        })
+
+    return {
+        'status': 'completed',
+        'batch_id': batch_id,
+        'transfer_items': transfer_items,
+    }
+
+
+if __name__ == '__main__':
+    TOKEN_FILE = '/opt/config/smartscope_tokens.json'
+    CLIENT_ID = '7df9d534-fb19-4d79-8e83-642f1cdcf081'
+
+    tokens = json.loads(Path(TOKEN_FILE).read_text())
+    t = tokens['funcx_service']
+    auth_client = NativeAppAuthClient(CLIENT_ID)
+    authorizer = RefreshTokenAuthorizer(
+        t['refresh_token'], auth_client,
+        access_token=t['access_token'],
+        expires_at=t['expires_at_seconds'],
+    )
+    cc = ComputeClientV2(authorizer=authorizer)
+
+    reg_data = FunctionRegistrationData(function=run_preprocessing)
+    result = cc.post('/v3/functions', data=reg_data.to_dict())
+    func_id = result.data['function_uuid']
+    print(f'Function ID: {func_id}')
+    print('Update the SmartScope form "Compute Function ID" field with this value.')

--- a/scripts/setup_globus.py
+++ b/scripts/setup_globus.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""SmartScope Globus Pipeline Setup.
+
+One-stop script to authenticate with Globus, deploy the preprocessing
+flow, and register the compute function. Run inside the SmartScope
+container or anywhere with globus-sdk installed.
+
+Usage:
+    python setup_globus.py                              # Interactive: auth + deploy + register
+    python setup_globus.py auth                         # Just authenticate
+    python setup_globus.py deploy-flow                  # Just deploy/update the flow
+    python setup_globus.py register-func                # Register the default compute function
+    python setup_globus.py register-func -f my_func.py  # Register a custom compute function
+    python setup_globus.py status                       # Show current config
+
+To write a custom compute function, copy scripts/compute_function_template.py
+and implement the run_preprocessing() function for your HPC environment.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+# ---------- Defaults ----------
+
+CLIENT_ID = "7df9d534-fb19-4d79-8e83-642f1cdcf081"
+TOKEN_FILE = Path("/opt/config/smartscope_tokens.json")
+FLOW_DEFINITION_FILE = Path(__file__).resolve().parent.parent / \
+    "Smartscope" / "core" / "pipelines" / "globus_flow_definition.json"
+
+# All scopes needed for the full pipeline
+SCOPES = [
+    "urn:globus:auth:scope:transfer.api.globus.org:all",
+    "https://auth.globus.org/scopes/eec9b274-0c81-4334-bdc2-54e90e689b9a/manage_flows",
+    "https://auth.globus.org/scopes/eec9b274-0c81-4334-bdc2-54e90e689b9a/run_manage",
+    "https://auth.globus.org/scopes/eec9b274-0c81-4334-bdc2-54e90e689b9a/view_flows",
+    "https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all",
+]
+
+# ---------- Token helpers ----------
+
+def _load_tokens():
+    if TOKEN_FILE.exists():
+        return json.loads(TOKEN_FILE.read_text())
+    return {}
+
+def _save_tokens(tokens):
+    TOKEN_FILE.parent.mkdir(parents=True, exist_ok=True)
+    TOKEN_FILE.write_text(json.dumps(tokens, indent=2))
+    TOKEN_FILE.chmod(0o600)
+
+# ---------- Auth ----------
+
+def do_auth():
+    from globus_sdk import NativeAppAuthClient
+
+    print("\n=== Globus Authentication ===\n")
+
+    auth_client = NativeAppAuthClient(CLIENT_ID)
+    auth_client.oauth2_start_flow(
+        requested_scopes=SCOPES,
+        refresh_tokens=True,
+    )
+
+    url = auth_client.oauth2_get_authorize_url()
+    print(f"Visit this URL and log in:\n\n  {url}\n")
+    code = input("Paste the authorization code here: ").strip()
+
+    token_response = auth_client.oauth2_exchange_code_for_tokens(code)
+
+    # Merge into existing tokens (preserves funcx_service etc.)
+    existing = _load_tokens()
+    for rs, data in token_response.by_resource_server.items():
+        existing[rs] = dict(data)
+    _save_tokens(existing)
+
+    print(f"\nTokens saved to {TOKEN_FILE}")
+    for rs in token_response.by_resource_server:
+        print(f"  - {rs}")
+
+    return existing
+
+# ---------- Deploy Flow ----------
+
+def do_deploy_flow(tokens=None):
+    from globus_sdk import NativeAppAuthClient, FlowsClient, RefreshTokenAuthorizer
+
+    print("\n=== Deploy Globus Flow ===\n")
+
+    if tokens is None:
+        tokens = _load_tokens()
+
+    if "flows.globus.org" not in tokens:
+        print("Error: No flows token. Run 'setup_globus.py auth' first.")
+        return None
+
+    auth_client = NativeAppAuthClient(CLIENT_ID)
+    t = tokens["flows.globus.org"]
+    authorizer = RefreshTokenAuthorizer(
+        t["refresh_token"], auth_client,
+        access_token=t["access_token"],
+        expires_at=t["expires_at_seconds"],
+    )
+    fc = FlowsClient(authorizer=authorizer)
+
+    definition = json.loads(FLOW_DEFINITION_FILE.read_text())
+    input_schema = {
+        "type": "object",
+        "required": ["input"],
+        "properties": {
+            "input": {
+                "type": "object",
+                "required": ["source_collection", "destination_collection",
+                             "compute_endpoint", "compute_function",
+                             "compute_kwargs", "transfer_items", "label"],
+                "properties": {
+                    "source_collection": {"type": "string"},
+                    "destination_collection": {"type": "string"},
+                    "compute_endpoint": {"type": "string"},
+                    "compute_function": {"type": "string"},
+                    "compute_kwargs": {"type": "object"},
+                    "transfer_items": {"type": "array"},
+                    "label": {"type": "string"},
+                    "results_label": {"type": "string"},
+                },
+                "additionalProperties": False,
+            },
+        },
+        "additionalProperties": False,
+    }
+
+    # Check for existing SmartScope flows
+    existing_flows = []
+    for flow in fc.list_flows():
+        if "SmartScope" in flow.get("title", ""):
+            existing_flows.append(flow)
+
+    def _create_new_flow():
+        title = input("Flow title [SmartScope Globus Preprocessing]: ").strip()
+        title = title or "SmartScope Globus Preprocessing"
+
+        # Get subscription ID if user has multiple
+        try:
+            result = fc.create_flow(title=title, definition=definition, input_schema=input_schema)
+        except Exception as e:
+            if "SUBSCRIPTION_MUST_BE_SPECIFIED" in str(e):
+                sub_id = input("Subscription ID (from Globus web app): ").strip()
+                result = fc.create_flow(title=title, definition=definition,
+                                        input_schema=input_schema, subscription_id=sub_id)
+            else:
+                raise
+        return result["id"]
+
+    if existing_flows:
+        print("Existing SmartScope flows found:")
+        for i, flow in enumerate(existing_flows):
+            print(f"  [{i+1}] {flow['title']}  ({flow['id']})")
+        print(f"  [N] Deploy a new flow")
+
+        choice = input("\nUpdate existing or deploy new? ").strip()
+        if choice.upper() == "N":
+            flow_id = _create_new_flow()
+            print(f"\nNew flow deployed: {flow_id}")
+        else:
+            idx = int(choice) - 1
+            flow_id = existing_flows[idx]["id"]
+            fc.update_flow(flow_id, definition=definition, input_schema=input_schema)
+            print(f"\nFlow updated: {flow_id}")
+    else:
+        flow_id = _create_new_flow()
+        print(f"\nFlow deployed: {flow_id}")
+
+    # Re-auth with flow-specific scope
+    _reauth_for_flow(flow_id, tokens)
+
+    return flow_id
+
+def _reauth_for_flow(flow_id, tokens):
+    """Add flow-specific run scope to tokens."""
+    from globus_sdk import NativeAppAuthClient, SpecificFlowClient
+
+    flow_scope = SpecificFlowClient(flow_id).scopes.user
+    if any(flow_id in str(v) for v in tokens.values()):
+        return  # Already have flow-specific tokens
+
+    print(f"\nFlow-specific auth needed for {flow_id}")
+    auth_client = NativeAppAuthClient(CLIENT_ID)
+    auth_client.oauth2_start_flow(
+        requested_scopes=SCOPES + [flow_scope],
+        refresh_tokens=True,
+    )
+    url = auth_client.oauth2_get_authorize_url()
+    print(f"\nVisit this URL:\n\n  {url}\n")
+    code = input("Paste the authorization code: ").strip()
+
+    token_response = auth_client.oauth2_exchange_code_for_tokens(code)
+    for rs, data in token_response.by_resource_server.items():
+        tokens[rs] = dict(data)
+    _save_tokens(tokens)
+    print("Flow-specific tokens saved.")
+
+# ---------- Register Compute Function ----------
+
+def do_register_function(tokens=None, function_file=None):
+    from globus_sdk import NativeAppAuthClient, ComputeClientV2, RefreshTokenAuthorizer
+    from globus_compute_sdk.sdk.client import FunctionRegistrationData
+    import importlib.util
+
+    print("\n=== Register Compute Function ===\n")
+
+    if tokens is None:
+        tokens = _load_tokens()
+
+    if "funcx_service" not in tokens:
+        print("Error: No compute token. Run 'setup_globus.py auth' first.")
+        return None
+
+    auth_client = NativeAppAuthClient(CLIENT_ID)
+    t = tokens["funcx_service"]
+    authorizer = RefreshTokenAuthorizer(
+        t["refresh_token"], auth_client,
+        access_token=t["access_token"],
+        expires_at=t["expires_at_seconds"],
+    )
+    cc = ComputeClientV2(authorizer=authorizer)
+
+    # Load the compute function from file
+    if function_file is None:
+        function_file = str(Path(__file__).resolve().parent / "register_compute_function.py")
+        print(f"Using default function: {function_file}")
+    else:
+        print(f"Using custom function: {function_file}")
+
+    spec = importlib.util.spec_from_file_location("compute_func", function_file)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    if not hasattr(mod, "run_preprocessing"):
+        print(f"Error: {function_file} must define a 'run_preprocessing' function.")
+        return None
+
+    func = mod.run_preprocessing
+    reg_data = FunctionRegistrationData(function=func)
+    result = cc.post("/v3/functions", data=reg_data.to_dict())
+    func_id = result.data["function_uuid"]
+
+    print(f"Function registered: {func_id}")
+    print(f"Source: {function_file}")
+
+    return func_id
+
+# ---------- Status ----------
+
+def do_status():
+    print("\n=== SmartScope Globus Status ===\n")
+
+    tokens = _load_tokens()
+    if not tokens:
+        print(f"No tokens found at {TOKEN_FILE}")
+        return
+
+    print(f"Token file: {TOKEN_FILE}")
+    print(f"Token scopes:")
+    for rs in tokens:
+        print(f"  - {rs}")
+
+    print(f"\nFlow definition: {FLOW_DEFINITION_FILE}")
+    print(f"  Exists: {FLOW_DEFINITION_FILE.exists()}")
+
+# ---------- Interactive Setup ----------
+
+def do_full_setup():
+    print("=" * 50)
+    print("  SmartScope Globus Pipeline Setup")
+    print("=" * 50)
+
+    # Step 1: Auth
+    tokens = _load_tokens()
+    if tokens and "flows.globus.org" in tokens and "funcx_service" in tokens:
+        reauth = input("\nExisting tokens found. Re-authenticate? [y/N]: ").strip().lower()
+        if reauth == "y":
+            tokens = do_auth()
+    else:
+        tokens = do_auth()
+
+    # Step 2: Deploy flow
+    flow_id = do_deploy_flow(tokens)
+
+    # Step 3: Register function
+    func_id = do_register_function(tokens)
+
+    # Summary
+    print("\n" + "=" * 50)
+    print("  Setup Complete")
+    print("=" * 50)
+    print(f"\n  Flow ID:     {flow_id}")
+    print(f"  Function ID: {func_id}")
+    print(f"  Token file:  {TOKEN_FILE}")
+    print(f"\n  Enter these in the SmartScope preprocessing form,")
+    print(f"  or they will appear in the dropdowns automatically.")
+    print()
+
+
+# ---------- CLI ----------
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="SmartScope Globus Pipeline Setup",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    sub = parser.add_subparsers(dest="command")
+    sub.default = "setup"
+
+    sub.add_parser("setup", help="Full interactive setup (auth + deploy + register)")
+    sub.add_parser("auth", help="Authenticate with Globus")
+    sub.add_parser("deploy-flow", help="Deploy or update the Globus Flow")
+
+    reg = sub.add_parser("register-func", help="Register a compute function")
+    reg.add_argument("--function", "-f", metavar="FILE",
+                     help="Path to a Python file containing run_preprocessing(). "
+                          "Default: the bundled SLURM-based function. "
+                          "Copy scripts/compute_function_template.py to get started.")
+
+    sub.add_parser("status", help="Show current configuration")
+
+    args = parser.parse_args()
+    cmd = args.command or "setup"
+
+    if cmd == "setup":
+        do_full_setup()
+    elif cmd == "auth":
+        do_auth()
+    elif cmd == "deploy-flow":
+        do_deploy_flow()
+    elif cmd == "register-func":
+        do_register_function(function_file=getattr(args, "function", None))
+    elif cmd == "status":
+        do_status()


### PR DESCRIPTION
## Globus Preprocessing Pipeline

Adds a new preprocessing pipeline that offloads cryo-EM preprocessing to a remote HPC cluster via Globus Transfer and Globus Compute.

### Architecture

The pipeline uses a three-step Globus Flow:

1. **Transfer to HPC** — Movie files, .mdoc sidecars, and gain references are transferred from the microscope to the HPC via Globus Transfer
2. **Run compute function** — A user-selected Globus Compute function processes the movies (motion correction, CTF, picking, etc.) and writes a `.done.json` results file
3. **Transfer results back** — Thumbnails and the `.done.json` are transferred back to SmartScope

The flow definition is generic — the compute function UUID is a runtime parameter, not hardcoded. Users can register custom compute functions for different processing backends (Doppio/SLURM, CryoSPARC, RELION, etc.). JSON schemas in `Smartscope/core/pipelines/schemas/` define the contract between SmartScope and any compute function.

**Transfer-only mode**: If no flow/compute function is configured, the pipeline falls back to just transferring files to the HPC (no remote processing).

### Key features

- Configurable image grouping: per micrograph, per BIS group, or per grid square
- Settle time prevents submitting partial BIS groups while the microscope is still acquiring
- Concurrent flow limiting with automatic resubmission for late-arriving images
- Results update the SmartScope DB with CTF resolution, defocus, motion, particle count, ice thickness
- Selector plugins display preprocessing metrics as color-coded overlays in the grid viewer
- Generic key-value config passthrough — SmartScope is decoupled from any specific processing backend

### Setup

```bash
# Inside the SmartScope container:
python scripts/setup_globus.py           # Interactive: auth + deploy flow + register function
python scripts/setup_globus.py auth      # Just authenticate with Globus
python scripts/setup_globus.py deploy-flow    # Deploy/update the Globus Flow
python scripts/setup_globus.py register-func  # Register the default compute function
python scripts/setup_globus.py register-func -f my_function.py  # Register a custom function
```

To write a custom compute function, copy `scripts/compute_function_template.py` and implement `run_preprocessing()`.

### Changes to existing files

| File | Change | Reason |
|------|--------|--------|
| `preprocessing_pipelines.py` | Added `GlobusPreprocessingPipeline` to import and factory | Register the new pipeline |
| `selector_sorter.py` | None-safety for `values_range`, `set_limits`, `get_class`, `selector_value_within_limits` | Handles partial preprocessing results where some holes don't have metrics yet |
| `views.py` | Pass `grid_id` from query string into template context; return 400 on form validation failure | Pipeline form needs to know which grid it's configuring; validation errors were silently swallowed |
| `preprocessing_pipeline.html` | Pass `grid_id` via `hx-vals` in HTMX form | Preserves grid context during HTMX pipeline form loading |
| `pyproject.toml` | Added `globus` optional dependency group | `globus-sdk` and `globus-compute-sdk` |

### New files

| File | Purpose |
|------|---------|
| `globus_preprocessing_pipeline.py` | Main pipeline: grouping, submission, flow tracking, result parsing |
| `globus_pipeline_config.py` | Pydantic config model (collections, endpoints, slots, concurrency) |
| `globus_pipeline_form.py` | Django form with Globus API-populated dropdowns |
| `globus_flow_definition.json` | Generic Globus Flow: transfer → compute → transfer back |
| `schemas/*.schema.json` | JSON schemas for manifest, results, and function return value |
| `config/smartscope/plugins/preprocessing_*.yaml` | Selector plugins for CTF, motion, picking, ice thickness |
| `scripts/setup_globus.py` | One-stop setup: auth, flow deployment, function registration |
| `scripts/register_compute_function.py` | Default SLURM-based compute function |
| `scripts/compute_function_template.py` | Documented skeleton for custom compute functions |
