### PR TITLE
fix: on square processing error, update selected flag

### DIFF
--- a/Smartscope/core/grid/run_square.py
+++ b/Smartscope/core/grid/run_square.py
@@ -93,7 +93,6 @@ class RunSquare:
         except Exception as e:
             square = update(square,
                     status=status.ERROR,
-                    selected=False,
                     completion_time=timezone.now()
                 )
             logger.info(f"Status of the square {square.name} is set to ERROR")

--- a/Smartscope/core/grid/run_square.py
+++ b/Smartscope/core/grid/run_square.py
@@ -93,6 +93,7 @@ class RunSquare:
         except Exception as e:
             square = update(square,
                     status=status.ERROR,
+                    selected=False,
                     completion_time=timezone.now()
                 )
             logger.info(f"Status of the square {square.name} is set to ERROR")

--- a/Smartscope/core/navigation.py
+++ b/Smartscope/core/navigation.py
@@ -37,7 +37,7 @@ class OriginalNavigationStrategy(NavigationStrategy):
 
     def get_square_queue(self):
         return self.grid.squaremodel_set.filter(selected=True).\
-            exclude(status__in=[status.SKIPPED, status.COMPLETED]+status().in_flight_statuses).\
+            exclude(status__in=[status.SKIPPED, status.COMPLETED, status.ERROR]+status().in_flight_statuses).\
             order_by('number')
             
 

--- a/Smartscope/server/api/views.py
+++ b/Smartscope/server/api/views.py
@@ -224,8 +224,12 @@ class ReportPanel(APIView):
             context['grid'] = grid
             context['tagsFeatureFlag'] = settings.TAGS_FEATURE_FLAG
             context['gridform'] = AutoloaderGridReportForm(instance=context['grid'])
-            context['gridCollectionParamsForm'] = GridCollectionParamsForm(instance=context['grid'].params_id, grid_id=context['grid'].grid_id, 
-                                                                           initial={'detector': str(grid.session_id.detector_id.pk), 'mode': grid.collection_mode})
+            detector_id = grid.session_id.detector_id
+            context['gridCollectionParamsForm'] = GridCollectionParamsForm(instance=context['grid'].params_id, 
+                                                                           grid_id=context['grid'].grid_id, 
+                                                                           initial={'detector': str(detector_id.pk) if detector_id is not None else None, 
+                                                                                    'mode': grid.collection_mode}
+                                                                            )
             context['useMicroscope'] = settings.USE_MICROSCOPE
             try:
                 context['atlas_id'] = context['grid'].atlasmodel_set.all().first().atlas_id

--- a/static/reports.css
+++ b/static/reports.css
@@ -276,6 +276,12 @@
     color: orange;
 }
 
+.error {
+    stroke: rgb(194, 19, 19);
+    /* fill: green; */
+    color: rgb(194, 19, 19);
+}
+
 .completed.has_queued {
     fill-opacity: 0.6;
     fill: orange;


### PR DESCRIPTION
When a square record is updated after an error, the selected flag is not changed.
Changes:
* Changed the selected flag to False upon getting an error
* Added status.ERROR to the exclude list in get_square_queue