### PR TITLE
Add cross-service correlation logging and a diagnostics collector

### DIFF
--- a/Docker/SmartScope/collect_diagnostics.sh
+++ b/Docker/SmartScope/collect_diagnostics.sh
@@ -1,0 +1,50 @@
+#! /bin/bash
+#
+# collect_diagnostics.sh - bundle SmartScope logs, container state, config and
+# host health for a developer to diagnose an issue. Run from this directory:
+# Config is included; PASSWORD/SECRET/KEY/TOKEN values in *.conf are redacted.
+
+# --- command resolution: reused verbatim from smartscope.sh (lines 3-15) ---
+readonly cmd_file="dockerCmd.txt"
+composeCmd="docker compose"
+dockerCmd="docker"
+
+if [ -e "$cmd_file" ]; then
+    {
+        read -r dockerCmd
+        read -r composeCmd
+    } < "$cmd_file"
+    echo "Using docker command: $dockerCmd"
+    echo "Using docker-compose command: $composeCmd"
+fi
+
+cd $(dirname "$(readlink -f "$0")")
+
+compose="$composeCmd -f docker-compose.yml -f smartscope.yml"
+
+out="diag-$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$out/config" "$out/system"
+
+# Logs + container state
+[ -d ./logs ] && cp -R ./logs "$out/logs"
+$compose logs --no-color --tail=1000 > "$out/compose_logs.txt" 2>&1
+$compose ps -a                       > "$out/services.txt"     2>&1
+$compose images                      > "$out/images.txt"       2>&1
+
+# Config (whole folder; secrets in *.conf redacted)
+for f in docker-compose.yml smartscope.yml smartscope.sh smartscope.ps1 shared/initialdb.sql; do
+    [ -f "$f" ] && cp "$f" "$out/config/"
+done
+for f in smartscope.conf database.conf; do
+    [ -f "$f" ] && sed -E 's/^([[:space:]]*[A-Za-z_][A-Za-z0-9_]*(PASSWORD|PASSWD|SECRET|_KEY|TOKEN|API_?KEY)[[:space:]]*=).*/\1 <hidden>/I' "$f" > "$out/config/$f"
+done
+
+# Host / system health
+df -h                        > "$out/system/disk.txt"           2>&1
+$dockerCmd stats --no-stream > "$out/system/docker_stats.txt"   2>&1
+$compose top                 > "$out/system/compose_top.txt"    2>&1
+$dockerCmd version           > "$out/system/docker_version.txt" 2>&1
+uname -a                     > "$out/system/host.txt"           2>&1
+
+tar -czf "$out.tar.gz" "$out" && rm -rf "$out"
+echo "Created $out.tar.gz  (logs + config + system state; passwords redacted)"

--- a/Docker/SmartScope/docker-compose.yml
+++ b/Docker/SmartScope/docker-compose.yml
@@ -35,6 +35,8 @@ services:
       - smartscope.conf
     volumes:
       - ./scratch/:/mnt/scratch/:rw
+      - ./logs/ai/:/opt/logs/
+      # added volume for SMARTSCOPE_AI
     networks:
       - smartscopenet
     command: ["celery", "-A", "SmartscopeAI.interfaces.celery.app", "worker", "--loglevel=DEBUG", "--pool=solo", "-Q", "smartscope_ai_cpu"]

--- a/Smartscope/tasks/base_tasks.py
+++ b/Smartscope/tasks/base_tasks.py
@@ -78,16 +78,19 @@ def send_find_squares_from_montage(montage, class_map:Dict[str,BaseModel], **kwa
     data['kwargs']['class_mapping'] = {k:v.model_dump() for k,v in class_map.items()}
 
     queue, scratch_dir = get_queue()
-    print(f'Sending find_squares task to queue {queue} with scratch dir {scratch_dir}')
-    
+    #print(f'Sending find_squares task to queue {queue} with scratch dir {scratch_dir}')
+    logger.debug(f'Sending find_squares task to queue {queue} with scratch dir {scratch_dir}')
     result = app.send_task('SmartscopeAI.interfaces.celery.tasks.find_squares', args=[json.dumps(data)], queue=queue)
     task_id = result.id
+    logger.info(f"[grid={kwargs.get('grid_id', '-')}] dispatched find_squares -> task_id={task_id}")
     res = AsyncResult(task_id, app=app)
     coords, labels = res.get(interval=1, timeout=120)
     yolo_class_map = class_map_to_yolo(class_map=class_map)
-    print(labels)
+    #print(labels)
+    logger.debug(f'find_squares labels: {labels}')
     labels_converted =  [yolo_class_map[item] for item in labels]
-    print(coords, labels_converted)
+    #print(coords, labels_converted)
+    logger.debug(f'find_squares coords: {coords}, labels: {labels_converted}')
     return (coords,labels_converted), True, dict()
 
 def send_find_holes_from_montage(montage:Montage, class_map:Dict[str,BaseModel], success_threshold:int=10,  **kwargs):
@@ -103,9 +106,11 @@ def send_find_holes_from_montage(montage:Montage, class_map:Dict[str,BaseModel],
     
     result = app.send_task('SmartscopeAI.interfaces.celery.tasks.find_holes', args=[json.dumps(data)], queue=get_queue()[0])
     task_id = result.id
+    logger.info(f"[grid={kwargs.get('grid_id', '-')}] dispatched find_holes -> task_id={task_id}")
     res = AsyncResult(task_id, app=app)
     final_result = res.get(interval=1, timeout=120)
-    print(final_result)
+    #print(final_result)
+    logger.debug(f'find_holes result: {final_result}')
     return final_result, True, dict()
 
 def send_find_holes_from_square(montage:Montage, class_map:Dict[str,BaseModel], success_threshold:int=10,  **kwargs):
@@ -122,9 +127,11 @@ def send_find_holes_from_square(montage:Montage, class_map:Dict[str,BaseModel], 
     
     result = app.send_task('SmartscopeAI.interfaces.celery.tasks.find_holes', args=[json.dumps(data)], queue=get_queue()[0])
     task_id = result.id
+    logger.info(f"[grid={kwargs.get('grid_id', '-')}] dispatched find_holes -> task_id={task_id}")
     res = AsyncResult(task_id, app=app)
     final_result = res.get(interval=1, timeout=600)
-    print(final_result)
+    #print(final_result)
+    logger.debug(f'find_holes result: {final_result}')
     return final_result, True, dict()
 
 def find_holes_with_lattice(montage, hole_spacing:float, hole_size:float, lattice_radius:float, class_map:Dict=None, success_threshold:int=2, **kwargs):
@@ -190,10 +197,11 @@ def sim_siam_inference(mag_level:Literal['square','hole'], grid_id:str, **kwargs
     checkpoint_path = None
     config_path = None
     queue, scratch_dir = get_queue()
-    print(f'Sending find_squares task to queue {queue} with scratch dir {scratch_dir}')
-
+    #print(f'Sending find_squares task to queue {queue} with scratch dir {scratch_dir}')
+    logger.debug(f'Sending sim_siam task to queue {queue} with scratch dir {scratch_dir}')
     weights = sim_siam_find_checkpoint(mag_level, grid)
-    print(f'Found weights {weights} for mag level {mag_level} and grid {grid_id}')
+    #print(f'Found weights {weights} for mag level {mag_level} and grid {grid_id}')
+    logger.debug(f'Found weights {weights} for mag level {mag_level} and grid {grid_id}')
     if weights is not None:
         training_process = SimSiamTrainingProcess.objects.filter(sim_siam_weights=weights).first()
         checkpoint_path = (weights.checkpoint_file,Path(*training_process.training_results_weights.parts[1:]))
@@ -217,12 +225,15 @@ def sim_siam_inference(mag_level:Literal['square','hole'], grid_id:str, **kwargs
         checkpoint_path = str(checkpoint_path)
     ))
 
-    print(f'Sending SimSiam inference request for grid {grid_id} with magnification level {mag_level} and checkpoint {checkpoint_path}')
+    #print(f'Sending SimSiam inference request for grid {grid_id} with magnification level {mag_level} and checkpoint {checkpoint_path}')
+    logger.info(f'Sending SimSiam inference request for grid {grid_id}...')
     result = app.send_task('SmartscopeAI.interfaces.celery.tasks.sim_siam_data', args=[data], queue=queue)
     task_id = result.id
+    logger.info(f'[grid={grid_id}] dispatched sim_siam_data -> task_id={task_id}')
     res = AsyncResult(task_id, app=app)
     final_result = res.get(interval=1, timeout=600)
-    print(final_result)
+    #print(final_result)
+    logger.debug(f'sim_siam inference result: {final_result}')
     
     sim_siam_copy_output_file_from_scratch(final_result, grid.directory, scratch_dir=scratch_dir)
 
@@ -260,8 +271,10 @@ def sim_siam_training(mag_level:Literal['square','hole'], grid_id:str, related_g
         mag_level = mag_level,
         checkpoint_path = str(checkpoint_path)
     ))
-    print(f'Sending SimSiam training request for grid {grid_id} with magnification level {mag_level} and checkpoint {checkpoint_path}')
+    #print(f'Sending SimSiam training request for grid {grid_id} with magnification level {mag_level} and checkpoint {checkpoint_path}')
+    logger.info(f'Sending SimSiam training request for grid {grid_id}...')
     result = app.send_task('SmartscopeAI.interfaces.celery.tasks.sim_siam_training', args=[data], queue=queue)
+    logger.info(f'[grid={grid_id}] dispatched sim_siam_training -> task_id={result.id}')
     return result.id
     # res = AsyncResult(task_id, app=app)
     # final_result = res.get(interval=1, timeout=120)


### PR DESCRIPTION
Makes user-reported issues easier to diagnose across SmartScope and the SmartScopeAI worker.
  
  - base_tasks.py: log the grid + Celery task_id at each dispatch to the AI worker, so a request can be traced end-to-end via task_id (the worker already logs task_id on failure) and also converted print() to the logger.
  - collect_diagnostics.sh (new): bundles logs, container state, config, and host health into one diag-<timestamp>.tar.gz for debugging; .conf passwords are redacted. Follows smartscope.sh conventions.
  - docker-compose.yml: persist the AI worker log via a ./logs/ai volume.